### PR TITLE
fix(queue/kafka): pass SSL/SASL config to confluent client

### DIFF
--- a/tina4_python/queue_backends/kafka_backend.py
+++ b/tina4_python/queue_backends/kafka_backend.py
@@ -6,6 +6,9 @@ Kafka wire protocol over TCP sockets (zero dependencies).
 Environment variables:
     TINA4_KAFKA_BROKERS  — comma-separated broker list (default: localhost:9092)
     TINA4_KAFKA_GROUP_ID — consumer group ID (default: tina4_consumer_group)
+    KAFKA_SECURITY_PROTOCOL — e.g. SSL / SASL_SSL (default: PLAINTEXT)
+    KAFKA_SSL_CA_LOCATION   — CA cert path for TLS brokers/proxies
+    KAFKA_SASL_MECHANISM / KAFKA_SASL_USERNAME / KAFKA_SASL_PASSWORD — optional SASL
 """
 import json
 import os
@@ -147,16 +150,36 @@ class KafkaConnector:
     # ── Confluent-Kafka Implementation ───────────────────────────
 
     def _connect_confluent(self):
-        conf = {"bootstrap.servers": self._brokers, "client.id": self._client_id}
+        security = self._security_config()
+        conf = {"bootstrap.servers": self._brokers, "client.id": self._client_id, **security}
         self._producer = self._confluent.Producer(conf)
 
         consumer_conf = {
             "bootstrap.servers": self._brokers,
+            "client.id": self._client_id,
             "group.id": self._group_id,
             "auto.offset.reset": "earliest",
             "enable.auto.commit": False,
+            **security,
         }
         self._consumer = self._confluent.Consumer(consumer_conf)
+
+    @staticmethod
+    def _security_config() -> dict:
+        """Build SSL/SASL client config from env (for a TLS broker/proxy).
+
+        Honours KAFKA_SECURITY_PROTOCOL (e.g. SSL, SASL_SSL), KAFKA_SSL_CA_LOCATION,
+        and optional SASL (KAFKA_SASL_MECHANISM / KAFKA_SASL_USERNAME /
+        KAFKA_SASL_PASSWORD). Unset keys leave librdkafka defaults (PLAINTEXT).
+        """
+        mapping = {
+            "KAFKA_SECURITY_PROTOCOL": "security.protocol",
+            "KAFKA_SSL_CA_LOCATION": "ssl.ca.location",
+            "KAFKA_SASL_MECHANISM": "sasl.mechanism",
+            "KAFKA_SASL_USERNAME": "sasl.username",
+            "KAFKA_SASL_PASSWORD": "sasl.password",
+        }
+        return {rdk: os.environ[env] for env, rdk in mapping.items() if os.environ.get(env)}
 
     # ── Raw Kafka Wire Protocol Implementation ───────────────────
 


### PR DESCRIPTION
## Problem

The Kafka queue backend builds the confluent (librdkafka) producer/consumer with only `bootstrap.servers` + `client.id`. `security.protocol` therefore defaults to `PLAINTEXT`, so connecting to a TLS-only broker/proxy fails with:

```
Disconnected: connection closed by peer: receive 0 after POLLIN (after 22ms in state APIVERSION_QUERY)
```

That's a plaintext `ApiVersionRequest` being sent to a TLS listener — the broker/proxy closes the socket. Env vars like `KAFKA_SECURITY_PROTOCOL=SSL` / `KAFKA_SSL_CA_LOCATION` were simply never read by this backend.

## Fix

`_connect_confluent` now reads SSL/SASL settings from env and applies them to **both** the producer and the consumer (the consumer also gets a `client.id`, which it was missing):

- `KAFKA_SECURITY_PROTOCOL` → `security.protocol` (e.g. `SSL`, `SASL_SSL`)
- `KAFKA_SSL_CA_LOCATION` → `ssl.ca.location`
- optional `KAFKA_SASL_MECHANISM` / `KAFKA_SASL_USERNAME` / `KAFKA_SASL_PASSWORD`

Unset keys leave librdkafka defaults (`PLAINTEXT`), so existing plaintext users are unaffected — purely additive.

## Verification

Reproduced and validated against a TLS-only grepplabs kafka-proxy from the affected service's pod: a direct confluent client with `security.protocol=SSL` + the CA **connected (61 topics)**; without it, the `APIVERSION_QUERY` failure reproduced exactly. With this change the queue backend connects over TLS using the same env the deployment already sets — no manifest change required.