### PR TITLE
Migration: honour SET TERM directives when splitting statements (+ Firebird v2→v3 generator fix)

### DIFF
--- a/tests/test_migration_footguns.py
+++ b/tests/test_migration_footguns.py
@@ -6,6 +6,7 @@
 """
 from tina4_python.migration.runner import (
     _split_statements,
+    _parse_set_term,
     _migration_sort_key,
     _should_skip_create_table,
     _normalize_quotes,
@@ -43,6 +44,73 @@ def test_split_still_handles_real_stored_proc_block():
     sql = "CREATE PROCEDURE foo() // BEGIN SELECT 1; SELECT 2; END //;"
     stmts = _split_statements(sql, ";")
     assert any("BEGIN SELECT 1; SELECT 2; END" in s for s in stmts), stmts
+
+
+# ── SET TERM switches the terminator so PSQL bodies survive ──────────────
+
+def test_set_term_keeps_trigger_body_intact():
+    # A trigger body has ';'-terminated inner statements; under the default ';'
+    # runner it must survive as ONE statement, not be split on those inner ';'.
+    sql = (
+        "SET TERM ^ ;\n"
+        "CREATE OR ALTER TRIGGER t_bi FOR t ACTIVE BEFORE INSERT AS\n"
+        "BEGIN\n"
+        "  IF (NEW.id IS NULL) THEN NEW.id = GEN_ID(GEN_T, 1);\n"
+        "END^\n"
+        "SET TERM ; ^"
+    )
+    stmts = _split_statements(sql, ";")
+    assert len(stmts) == 1, f"trigger body was split on its inner ';': {stmts}"
+    assert stmts[0].startswith("CREATE OR ALTER TRIGGER")
+    assert stmts[0].endswith("END")
+    assert "NEW.id = GEN_ID(GEN_T, 1);" in stmts[0]
+
+
+def test_set_term_directives_are_consumed_not_emitted():
+    sql = "SET TERM ^ ;\nEXECUTE BLOCK AS BEGIN a; b; END^\nSET TERM ; ^"
+    stmts = _split_statements(sql, ";")
+    assert len(stmts) == 1
+    assert all("SET TERM" not in s for s in stmts), f"SET TERM leaked as SQL: {stmts}"
+
+
+def test_set_term_restores_previous_delimiter():
+    # After `SET TERM ; ^`, plain ';' splitting resumes.
+    sql = (
+        "CREATE TABLE a (id INT);\n"
+        "SET TERM ^ ;\n"
+        "CREATE TRIGGER a_bi FOR a AS BEGIN NEW.id = 1; END^\n"
+        "SET TERM ; ^\n"
+        "INSERT INTO a VALUES (1);\nUPDATE a SET id = 2;"
+    )
+    stmts = _split_statements(sql, ";")
+    assert len(stmts) == 4, f"delimiter not restored to ';' after the block: {stmts}"
+    assert stmts[0].startswith("CREATE TABLE")
+    assert stmts[1].startswith("CREATE TRIGGER")
+    assert stmts[2].startswith("INSERT INTO")
+    assert stmts[3].startswith("UPDATE")
+
+
+def test_set_term_supports_multi_char_terminator():
+    sql = "SET TERM !! ;\nCREATE TRIGGER t FOR x AS BEGIN NEW.a = 1; END!!\nSET TERM ; !!"
+    stmts = _split_statements(sql, ";")
+    assert len(stmts) == 1
+    assert "!!" not in stmts[0]
+    assert "SET TERM" not in stmts[0]
+
+
+def test_plain_semicolon_unaffected_by_set_term_support():
+    # No SET TERM → ordinary ';' splitting, behaviour unchanged.
+    sql = "CREATE TABLE a (id INT);\nINSERT INTO a VALUES (1);\nUPDATE a SET id = 2;"
+    stmts = _split_statements(sql, ";")
+    assert len(stmts) == 3
+    assert not any(s.endswith(";") for s in stmts)
+
+
+def test_parse_set_term_recognises_directive_only():
+    assert _parse_set_term("SET TERM ^") == "^"
+    assert _parse_set_term("set term !!") == "!!"
+    assert _parse_set_term("CREATE TABLE a (id INT)") is None
+    assert _parse_set_term("SELECT 'SET TERM ^ ;'") is None
 
 
 # ── smart/curly quotes normalized so the SQL runs ───────────────────────

--- a/tina4_python/migration/runner.py
+++ b/tina4_python/migration/runner.py
@@ -192,6 +192,16 @@ def _upgrade_v2_to_v3(db, migration_folder: str | None) -> None:
         "Detected legacy v2 tina4_migration schema — performing in-place upgrade to v3"
     )
 
+    # A v2 table has no id generator; on Firebird, ids for rows recorded after
+    # the upgrade come from GEN_TINA4_MIGRATION_ID (see _record_migration), so
+    # make sure it exists. Fresh v3 tables get it in _create_v3_table.
+    if _is_firebird(db):
+        try:
+            db.execute("CREATE GENERATOR GEN_TINA4_MIGRATION_ID")
+            db.commit()
+        except Exception:
+            pass  # Generator may already exist
+
     cols = _column_names(db)
 
     if "migration_id" not in cols:
@@ -331,6 +341,27 @@ def _normalize_quotes(sql: str) -> str:
     return _SMART_QUOTE_RE.sub(lambda m: _SMART_QUOTES[m.group(0)], sql)
 
 
+_SET_TERM_RE = re.compile(r"^SET\s+TERM\s+(\S+)$", re.IGNORECASE)
+
+
+def _parse_set_term(statement: str) -> str | None:
+    """Return the new terminator from a ``SET TERM <new> <current>`` directive.
+
+    ``SET TERM`` is a script-level directive (recognised by isql and other
+    InterBase/Firebird tooling, not run by the engine) that changes the
+    terminator separating statements. Recognising it lets a statement whose own
+    body contains the default ``;`` terminator — a trigger, stored procedure or
+    ``EXECUTE BLOCK`` — be kept intact rather than split on those inner ``;``.
+    The terminator may be more than one character (e.g. ``!!``).
+
+    :param statement: A single, already-stripped statement.
+    :returns: The new terminator, or ``None`` when *statement* is not a
+        ``SET TERM`` directive.
+    """
+    match = _SET_TERM_RE.match(statement.strip())
+    return match.group(1) if match else None
+
+
 def _split_statements(sql: str, delimiter: str = ";") -> list[str]:
     """Split SQL into individual statements with a single-pass, quote- and
     comment-aware scanner.
@@ -356,6 +387,10 @@ def _split_statements(sql: str, delimiter: str = ";") -> list[str]:
       a delimiter or comment, so it is preserved untouched.
     - The **delimiter** ends a statement only when reached outside all of the
       above. Empty statements are dropped; each kept statement is trimmed.
+    - A **SET TERM directive** (``SET TERM <new> <current>``) switches the active
+      terminator and is consumed, never emitted, so a statement whose own body
+      contains the default terminator survives as one. Multi-character
+      terminators (e.g. ``!!``) are supported.
 
     Smart/curly quotes are normalized to straight ASCII first. Mirrors the
     tina4-php ``Migration::splitStatements`` scanner for cross-framework parity.
@@ -367,7 +402,6 @@ def _split_statements(sql: str, delimiter: str = ";") -> list[str]:
     statements: list[str] = []
     current: list[str] = []
     n = len(sql)
-    dlen = len(delimiter)
     i = 0
     in_dollar_block = False
     in_slash_block = False
@@ -448,20 +482,28 @@ def _split_statements(sql: str, delimiter: str = ";") -> list[str]:
                     i += 1
             continue
 
-        # Statement delimiter — only reached outside blocks/comments/strings.
+        # Statement delimiter — only reached outside blocks/comments/strings. A
+        # SET TERM directive switches the active terminator and is consumed
+        # (never emitted); any other completed statement is collected.
         if delimiter and sql.startswith(delimiter, i):
+            i += len(delimiter)
             stmt = "".join(current).strip()
-            if stmt:
-                statements.append(stmt)
             current = []
-            i += dlen
+            if stmt:
+                new_term = _parse_set_term(stmt)
+                if new_term is not None:
+                    delimiter = new_term
+                else:
+                    statements.append(stmt)
             continue
 
         current.append(ch)
         i += 1
 
+    # Trailing statement (may not end with a delimiter). A trailing SET TERM
+    # directive is a no-op — consume it, don't emit it.
     stmt = "".join(current).strip()
-    if stmt:
+    if stmt and _parse_set_term(stmt) is None:
         statements.append(stmt)
     return statements
 


### PR DESCRIPTION
Cross-framework parity port of two tina4-php migration-runner fixes (SET TERM support + a Firebird v2→v3 generator fix), adapted to the Python runner.

## 1. SET TERM directive support in `_split_statements`

`_split_statements` now recognises the `SET TERM <new> <current>` directive (the isql/InterBase/Firebird idiom). While a non-`;` terminator is in effect, a statement whose own body contains the default `;` terminator — a trigger, stored procedure or `EXECUTE BLOCK` — is kept as one statement instead of being split on those inner `;`.

- The directive is **consumed**, never emitted as SQL.
- The active terminator is switched until the next `SET TERM` resets it; **multi-character** terminators (e.g. `!!`) are supported.
- **No-op for any script without `SET TERM`** — plain `;` splitting is unchanged (regression-locked by `test_plain_semicolon_unaffected_by_set_term_support`).

```sql
SET TERM ^ ;
CREATE OR ALTER TRIGGER t_bi FOR t ACTIVE BEFORE INSERT AS
BEGIN
  IF (NEW.id IS NULL) THEN NEW.id = GEN_ID(GEN_T, 1);
END^
SET TERM ; ^
```

## 2. Ensure the id generator exists on a Firebird v2→v3 upgrade

A legacy v2 `tina4_migration` table has no id generator. On Firebird, ids for migrations recorded *after* the in-place upgrade come from `GEN_TINA4_MIGRATION_ID` (via `_record_migration`), but `_upgrade_v2_to_v3` never created it — only `_create_v3_table` (the fresh-table path) did. So the first migration recorded after a v2→v3 upgrade on Firebird could fail on a missing generator. `_upgrade_v2_to_v3` now creates it (idempotent).

## Tests

6 new cases in `tests/test_migration_footguns.py`, exercising the real `_split_statements` / `_parse_set_term` (no mocks): trigger-body-intact, directive-consumed, delimiter-restore, multi-char terminator, plain-`;` unaffected, and `_parse_set_term` recognition. Full file: **22 passed** under pytest.

## Parity

Sibling PRs port SET TERM to tina4-php (#126), tina4-ruby, and tina4-nodejs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)