### PR TITLE
fix(orm): skip callable defaults in create_table() DDL (#61)

### DIFF
--- a/tina4_python/orm/model.py
+++ b/tina4_python/orm/model.py
@@ -907,7 +907,12 @@ class ORM(metaclass=ORMMeta):
                 parts.append("AUTOINCREMENT")
             if field_obj.required and not field_obj.primary_key:
                 parts.append("NOT NULL")
-            if field_obj.default is not None and not field_obj.auto_increment and kind != "JSONField":
+            # Callable defaults (e.g. DateTimeField(default=lambda: datetime.now())) are
+            # resolved per-row at insert time (_resolve_default, issue #50); they must NOT
+            # be emitted into the CREATE TABLE DDL, where they stringify to an invalid
+            # `DEFAULT <function ...>` and silently fail table creation.
+            if field_obj.default is not None and not field_obj.auto_increment \
+                    and kind != "JSONField" and not callable(field_obj.default):
                 default_val = field_obj.default
                 if isinstance(default_val, str):
                     parts.append(f"DEFAULT '{default_val}'")


### PR DESCRIPTION
Fixes #61.

`create_table()` stringified callable field defaults (e.g. `DateTimeField(default=lambda: datetime.now())`) into the DDL as `DEFAULT <function ...>` — invalid SQL. It logs but doesn't raise, so the table is **silently never created** and later `.save()`/`.all()` fail with `no such table`.

Callable defaults are already resolved per-row at insert (`_resolve_default`, #50), so they must not appear in DDL. This adds a `callable()` guard to the default branch (`orm/model.py`).

**Verified on 3.13.56:** `create_table()` now succeeds, rows persist, and `created_at` resolves per-insert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)