### PR TITLE
skills+db: document sqlite URL slash footgun; fix contradictory comment

### DIFF
--- a/.claude/skills/tina4-developer-python/SKILL.md
+++ b/.claude/skills/tina4-developer-python/SKILL.md
@@ -553,6 +553,13 @@ mongodb://user:password@localhost:27017/mydb
 
 ## Testing
 
+> **SQLite URL footgun — mind the slashes.** Bind a **relative** sqlite URL for test / temp
+> databases: `sqlite:///data/test.db` (three slashes = relative to cwd — identical on every
+> backend). Never build the URL from a raw absolute path (e.g. `"sqlite:" + abs_path`, which
+> yields a single leading slash) — python/ruby read that as *relative*, so the DB is silently
+> created somewhere else and a test's DB-reset misses it (stale rows → flaky assertions). For a
+> genuine absolute path use the four-slash form `sqlite:////abs/path.db`.
+
 Tests are written alongside the code:
 
 ```bash

--- a/tina4_python/database/connection.py
+++ b/tina4_python/database/connection.py
@@ -274,7 +274,8 @@ class Database:
         parsed = urlparse(self.url)
         scheme = parsed.scheme.lower()
 
-        # Handle sqlite:///path (three slashes = absolute, two = relative)
+        # Handle sqlite: URLs — see _connection_path for the slash rule
+        # (three slashes = relative to cwd, four = absolute).
         if scheme.startswith("sqlite"):
             scheme = "sqlite"
 


### PR DESCRIPTION
Steer the skill away from the naive `sqlite:{abspath}` form (a single leading slash reads as *relative* on python/ruby → DB silently lands elsewhere → flaky tests, as the method dry-run surfaced). Testing note added: use a relative `sqlite:///data/test.db` for temp DBs, four-slash `sqlite:////abs` for absolute. Also fixes a `connection.py` comment that contradicted the `_connection_path` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)