### PR TITLE
db: fix sqlite absolute-path footgun (cross-backend parity)

### DIFF
--- a/plan/sqlite-abspath-parity.md
+++ b/plan/sqlite-abspath-parity.md
@@ -1,0 +1,49 @@
+# Task: SQLite absolute-path footgun — cross-backend parity
+
+## Goal
+A naive `Database("sqlite:" + abs_path)` (one leading slash, e.g. `sqlite:/tmp/x.db`) must open the
+**absolute** file, not a path relative to cwd. All four backends identical; documented
+`sqlite:///relative` / `sqlite:////absolute` forms preserved.
+
+## Grounding — CORRECTED premise (verified empirically 2026-07-09; the task's premise was wrong)
+Root cause: python/php strip/collapse the one-slash form's leading `/` before the abs-check, so a
+naive absolute path silently became cwd-relative. nodejs threw. Only ruby was right.
+
+| Backend | `sqlite:/abs` before | Mechanism | Action |
+|---------|----------------------|-----------|--------|
+| python  | ❌ silently relative (`cwd/tmp/x.db`) | `urlparse` collapses `sqlite:/x`≡`sqlite:///x` | **FIXED** — raw-string strip |
+| php     | ❌ silently relative (`getDsn=tmp/abs/x.db`) | `sqlite:///`-only branch → generic `parse_url` drops the slash | **FIXED** — raw-string strip in `DatabaseUrl` |
+| nodejs  | ❌ throws "unsupported scheme" | `sqlite:/x` matched no branch → generic reject | **FIXED** — added `sqlite:` branch in `parseDatabaseUrl` |
+| ruby    | ✅ absolute (`/tmp/x.db`) | sequential `sub(sqlite:///)`→`sub(sqlite://)`→`sub(sqlite:)` | no code change — regression test only |
+
+Fix pattern (all): strip the scheme on the RAW url string in order `sqlite:///` → `sqlite://` →
+`sqlite:`, then let the adapter's absolute-detection (`/…` or `C:/…`) decide — mirroring ruby.
+
+## Scope
+- [x] python `connection.py` `_connection_path()` — raw-string strip (fix the 1-slash footgun)
+- [x] php `DatabaseUrl.php` — broaden `sqlite:///` branch to all `sqlite:` forms (raw-string strip)
+- [x] nodejs `database.ts` `parseDatabaseUrl()` — add `sqlite:` branch (keep leading slash)
+- [x] ruby — confirmed already correct (no code change)
+
+## Parity dashboard (probe-verified; committed tests below)
+| Case | python | php | ruby | nodejs |
+|------|--------|-----|------|--------|
+| `sqlite:/abs` → absolute file | ✅ (fixed) | ✅ (fixed) | ✅ | ✅ (fixed) |
+| `sqlite:////abs` → absolute (documented) | ✅ | ✅ | ✅ | ✅ |
+| `sqlite:///rel` → relative-to-cwd (documented) | ✅ | ✅ | ✅ | ✅ |
+
+## Tests (written FIRST / real — no mocks; run against the actual driver)
+- [x] python `tests/test_sqlite_abspath.py` — naive-abs opens abs file + documented forms; 4 pass; 626 DB/ORM/migration tests green (no regression)
+- [ ] php — worker writing PHPUnit test + running db suite
+- [ ] nodejs — worker writing tsx test + running orm suite
+- [ ] ruby — worker writing regression spec + running sqlite specs
+
+## Bugs
+- [x] python probe/pre-fix run polluted the repo (`tmp/`, `x.db`, `data/x.db`); cleaned. Also
+  accidentally `rm`'d two tracked `tmp/*.db` files — **restored** via `git restore` (kept the diff focused).
+
+## Commits
+- (python) pending — connection.py fix + test
+- (php/nodejs/ruby) pending — worker tests + fixes
+
+## Status: In Progress — python fixed+tested; php/nodejs fixed (probe-verified), tests in flight; ruby confirmed correct

--- a/tests/test_sqlite_abspath.py
+++ b/tests/test_sqlite_abspath.py
@@ -1,0 +1,38 @@
+"""SQLite absolute-path parity — a naive `sqlite:<abs>` (one leading slash) must open
+the ABSOLUTE file, not a path relative to cwd. Real driver, real files, no mocks."""
+import os
+import tempfile
+
+from tina4_python.database.connection import Database
+
+
+def test_naive_one_slash_absolute_path_opens_the_absolute_file(tmp_path, monkeypatch):
+    # Isolate cwd so any (buggy) cwd-relative shadow lands in tmp_path, not the repo.
+    monkeypatch.chdir(tmp_path)
+    abs_db = os.path.join(tempfile.mkdtemp(), "app.db")   # e.g. /var/folders/.../app.db
+
+    db = Database("sqlite:" + abs_db)                      # sqlite:/var/folders/.../app.db (ONE slash)
+
+    assert db._connection_path() == abs_db, "one-slash absolute path did not resolve to the abs path"
+    assert os.path.exists(abs_db), "DB not created at the absolute path (footgun resolved it relative)"
+    shadow = tmp_path / abs_db.lstrip("/")
+    assert not shadow.exists(), f"footgun: a cwd-relative shadow DB was created at {shadow}"
+
+
+def test_four_slash_absolute_form_unchanged():
+    # Documented absolute form: sqlite:/// + /abs == sqlite:////abs → absolute. Must not regress.
+    abs_db = os.path.join(tempfile.mkdtemp(), "app.db")
+    db = Database("sqlite:///" + abs_db, pool=1)           # lazy: inspect the resolved path only
+    assert db._connection_path() == abs_db
+
+
+def test_three_slash_relative_form_unchanged(tmp_path, monkeypatch):
+    # Documented relative form: sqlite:///rel → cwd/rel. Must not regress.
+    monkeypatch.chdir(tmp_path)                            # isolate cwd (path resolution mkdirs under it)
+    db = Database("sqlite:///data/app.db", pool=1)         # lazy: no connection
+    assert db._connection_path() == os.path.join(os.getcwd(), "data", "app.db")
+
+
+def test_memory_forms_unchanged():
+    assert Database("sqlite::memory:", pool=1)._connection_path() == ":memory:"
+    assert Database("sqlite:///:memory:", pool=1)._connection_path() == ":memory:"

--- a/tina4_python/database/connection.py
+++ b/tina4_python/database/connection.py
@@ -315,16 +315,32 @@ class Database:
             return self.url
 
         # In-memory forms — passthrough
-        raw_path = parsed.path
-        if raw_path in (":memory:", "/:memory:"):
+        if self.url in ("sqlite::memory:", "sqlite:///:memory:"):
             return ":memory:"
 
-        # Strip exactly one leading "/" — the URL "/"-delimiter between the
-        # empty netloc and the start of the path.
-        if raw_path.startswith("/"):
-            stripped = raw_path[1:]
+        # Strip the scheme on the RAW url string, NOT via urlparse. urlparse collapses
+        # "sqlite:/x" and "sqlite:///x" to the same .path, which loses the distinction
+        # between a one-slash ABSOLUTE path and the documented three-slash RELATIVE form —
+        # that was the "sqlite:<abspath> silently goes relative" footgun. Mirror the
+        # sequential strip php/ruby/nodejs use (strip sqlite:/// then sqlite:// then sqlite:):
+        #   sqlite:///app.db       → "app.db"        (three slashes = relative to cwd)
+        #   sqlite:///data/app.db  → "data/app.db"
+        #   sqlite:////abs/app.db  → "/abs/app.db"   (four slashes = absolute)
+        #   sqlite:///C:/Users/x   → "C:/Users/x"    (Windows absolute)
+        #   sqlite:/abs/app.db     → "/abs/app.db"   (one slash = a real absolute path)
+        #   sqlite://rel/app.db    → "rel/app.db"    (two-slash legacy = relative)
+        #   sqlite:app.db          → "app.db"        (relative)
+        url = self.url
+        if url.startswith("sqlite:///"):
+            stripped = url[len("sqlite:///"):]
+        elif url.startswith("sqlite://"):
+            stripped = url[len("sqlite://"):]
+        elif url.startswith("sqlite:"):
+            stripped = url[len("sqlite:"):]
         else:
-            stripped = raw_path
+            stripped = url
+        if stripped == ":memory:":
+            return ":memory:"
 
         # Windows absolute path (drive-letter form): C:/... or C:\...
         is_windows_abs = (
@@ -333,8 +349,8 @@ class Database:
             and stripped[1] == ":"
             and stripped[2] in ("/", "\\")
         )
-        # Unix absolute path: urlparse("sqlite:////abs/app.db").path == "//abs/app.db"
-        # After one strip it's still "/abs/app.db" → still starts with "/".
+        # Unix absolute path — a leading "/" that survived the scheme strip
+        # (four-slash "sqlite:////abs" or the one-slash "sqlite:/abs" form).
         is_unix_abs = stripped.startswith("/")
 
         if is_windows_abs or is_unix_abs:


### PR DESCRIPTION
A naive `Database("sqlite:" + abs_path)` (one leading slash) silently resolved **relative to cwd** — `_connection_path()` used `urlparse`, which collapses `sqlite:/x` and `sqlite:///x`. Now parses the raw URL string (strip `sqlite:///`→`sqlite://`→`sqlite:`) so a one-slash absolute path is absolute — **matching ruby** (which was already correct). php + nodejs get the same fix in their repos.

Documented forms unchanged (`sqlite:///rel`, `sqlite:////abs`, `:memory:`). Real tests in `tests/test_sqlite_abspath.py` (no mocks); 626 DB/ORM/migration tests green.

Part of the cross-backend SQLite absolute-path parity fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)