### PR TITLE
skills: document tina4 metrics + tina4 update CLI commands

### DIFF
--- a/.claude/skills/tina4-developer-python/SKILL.md
+++ b/.claude/skills/tina4-developer-python/SKILL.md
@@ -766,6 +766,11 @@ No shortcuts. No "we'll check it later." The check happens before the deploy, ev
 
 ### Monitor the Metrics Dashboard
 
+> **CLI:** run **`tina4 metrics`** for a code-health report in the terminal — the top complexity
+> offenders — with `--top N`, `--json`, `--path DIR`, and `--fail-on warn|error` (use the last to
+> fail a commit or CI on a complexity regression). Keep the `tina4` binary itself current with
+> **`tina4 update`** (self-updates to the latest release).
+
 The Tina4 Dev Admin panel (`/__dev/` → Metrics tab) provides a **live code health visualization**
 that every developer must use. It shows a bubble chart where:
 


### PR DESCRIPTION
Make the AI aware of two `tina4` CLI commands it didn't know:
- **`tina4 metrics`** — code-health / complexity report (top offenders; `--top N`, `--json`, `--path DIR`, `--fail-on warn|error` to gate CI).
- **`tina4 update`** — self-update the tina4 binary to the latest release.

Added to the metrics / code-quality section of each dev skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)