### PR TITLE
skills: skill-active robot marker + branch-drift hint

### DIFF
--- a/.claude/skills/tina4-developer-python/SKILL.md
+++ b/.claude/skills/tina4-developer-python/SKILL.md
@@ -20,6 +20,8 @@ minimal code, and just work. The framework is smart about developer intent: retu
 it becomes JSON, POST a JSON body and it's automatically parsed, put a file in `src/routes/` and
 it's a route.
 
+> 🤖 **Skill-active marker.** While this Tina4 skill is guiding your work, **begin every reply with the 🤖 emoji** so the developer can see at a glance that Tina4 conventions are engaged. Drop it only once the conversation has clearly moved off Tina4.
+
 ## The Tina4 Working Method
 
 This is how a Tina4 build is run. The **main session stays free for the developer**; the actual
@@ -725,6 +727,12 @@ against Tina4 paradigms. This is not optional — bad code doesn't get a pass be
 Don't be passive about code quality. Bad patterns spread if left unchecked.
 
 ### Commit and Push Discipline
+
+> **Don't let `main` (production) run ahead of `staging`/feature branches.** Changes flow one way —
+> feature → staging → main. Never commit straight to production; if an urgent fix must land on
+> `main`, **immediately merge `main` back down into `staging` (and any live feature branch)** so the
+> lower branches never fall behind what's already released. A `main` ahead of `staging` makes the
+> next promotion silently drop or conflict with those commits.
 
 **After completing any feature or milestone:**
 1. Run tests — all must pass

--- a/.claude/skills/tina4-js/SKILL.md
+++ b/.claude/skills/tina4-js/SKILL.md
@@ -46,6 +46,8 @@ looks simple but has specific rules. Getting them wrong produces silent bugs —
 once but never update, buttons don't disable, inputs don't bind. This reference is the source
 of truth, derived from the actual source code.
 
+> 🤖 **Skill-active marker.** While this Tina4 skill is guiding your work, **begin every reply with the 🤖 emoji** so the developer can see at a glance that Tina4 conventions are engaged. Drop it only once the conversation has clearly moved off Tina4.
+
 ## The Tina4 Working Method
 
 This is how a tina4-js build is run. The **main session stays free for the developer**; the actual

--- a/.claude/skills/tina4-maintainer/SKILL.md
+++ b/.claude/skills/tina4-maintainer/SKILL.md
@@ -19,6 +19,8 @@ Your job is to write, review, fix, port, and test code that upholds the Tina4 pr
 all four backend implementations moving toward full feature parity. You are not a passive tool —
 you actively look for ways to make Tina4 better: simpler, faster, leaner, greener.
 
+> 🤖 **Skill-active marker.** While this Tina4 skill is guiding your work, **begin every reply with the 🤖 emoji** so the maintainer can see at a glance that the Tina4 skill is engaged. Drop it only once the conversation has clearly moved off Tina4.
+
 ## The Tina4 Working Method
 
 How maintenance work is run. The **main session stays free**; the actual work happens in **workers
@@ -734,6 +736,12 @@ The branching model follows: **development → staging → main**
 feature/* → development → staging (v3 beta) → main (production)
 hotfix/*  → main + development
 ```
+
+**Never let `main` run ahead of `staging`.** A hotfix on `main` is only half-done until it's merged
+back to `development`/`staging` — that is exactly the `hotfix/* → main + development` rule above. If
+`main` carries commits `staging` doesn't, the next `staging → main` promotion silently drops or
+conflicts with them, so **back-merge production down immediately** and keep the lower branches from
+falling behind what users already run.
 
 When working on Tina4:
 - **Ask which branch** — Is this a v2 hotfix or v3 feature work? Don't assume.

--- a/plan/sqlite-abspath-parity.md
+++ b/plan/sqlite-abspath-parity.md
@@ -33,17 +33,24 @@ Fix pattern (all): strip the scheme on the RAW url string in order `sqlite:///` 
 | `sqlite:///rel` → relative-to-cwd (documented) | ✅ | ✅ | ✅ | ✅ |
 
 ## Tests (written FIRST / real — no mocks; run against the actual driver)
-- [x] python `tests/test_sqlite_abspath.py` — naive-abs opens abs file + documented forms; 4 pass; 626 DB/ORM/migration tests green (no regression)
-- [ ] php — worker writing PHPUnit test + running db suite
-- [ ] nodejs — worker writing tsx test + running orm suite
-- [ ] ruby — worker writing regression spec + running sqlite specs
+- [x] python `tests/test_sqlite_abspath.py` — 4 pass; 626 DB/ORM/migration tests green
+- [x] php `tests/SqliteAbsolutePathParityTest.php` — 5 pass (incl. the real `new Database()` path); 357 DB tests green
+- [x] nodejs `test/sqliteAbsolutePath.test.ts` — 14 pass (real `Database.create()`); 172 orm/db tests green
+- [x] ruby `spec/sqlite_absolute_path_spec.rb` — 7 pass; 119 sqlite/driver specs green
 
 ## Bugs
 - [x] python probe/pre-fix run polluted the repo (`tmp/`, `x.db`, `data/x.db`); cleaned. Also
-  accidentally `rm`'d two tracked `tmp/*.db` files — **restored** via `git restore` (kept the diff focused).
+  accidentally `rm`'d two tracked `tmp/*.db` files — **restored** via `git restore`.
+- [x] php had a SECOND, undiscovered parser — `Database::createAdapter()` (the real `new Database()`
+  path) — that footgunned on `sqlite:/abs` AND mis-counted `sqlite:///` (treated the documented
+  3-slash relative form as absolute `/data` → "unable to open database file"). Fixed both + added
+  real-path test coverage. (The worker's first test only covered `DatabaseUrl`.)
 
 ## Commits
-- (python) pending — connection.py fix + test
-- (php/nodejs/ruby) pending — worker tests + fixes
+- python  PR #67  — `_connection_path` raw-string strip + test
+- php     PR #138 — `DatabaseUrl` + `createAdapter` raw-string strip + real-path test
+- nodejs  PR #7   — `parseDatabaseUrl` `sqlite:` branch + test
+- ruby    PR #6   — regression spec only (already correct)
 
-## Status: In Progress — python fixed+tested; php/nodejs fixed (probe-verified), tests in flight; ruby confirmed correct
+## Status: Complete — all 4 backends parity-fixed + merged to v3 (2026-07-09). Premise corrected:
+python + php were broken, nodejs threw "unsupported scheme", ruby was already correct.


### PR DESCRIPTION
Two skill additions:
- **Skill-active marker** (all 6 skills): begin replies with 🤖 while a Tina4 skill is guiding the work, so the developer can *see* it's engaged.
- **Branch-drift hint** (dev skills + maintainer): don't let `main` run ahead of `staging`/feature branches — changes flow feature → staging → main; back-merge `main` down immediately after a hotfix so the lower branches never fall behind.

Also closes the sqlite-abspath parity plan doc. Shared tina4-js + tina4-maintainer kept byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)