### PR TITLE
docs: fix ORM select().to_array() serialization + ai: install skill files (for 3.13.60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,7 +797,7 @@ uv run tina4python test   # Discovers @tests in src/**/*.py
 Always read and follow the instructions in .claude/skills/tina4-maintainer/SKILL.md when working on this codebase. Read its referenced files in .claude/skills/tina4-maintainer/references/ as needed for specific subsystems.
 
 ## Tina4 Developer Skill
-Always read and follow the instructions in .claude/skills/tina4-developer/SKILL.md when building applications with this framework. Read its referenced files in .claude/skills/tina4-developer/references/ as needed.
+Always read and follow the instructions in .claude/skills/tina4-developer-python/SKILL.md when building applications with this framework. Read its referenced files in .claude/skills/tina4-developer-python/references/ as needed.
 
 ## Tina4-js Frontend Skill
 Always read and follow the instructions in .claude/skills/tina4-js/SKILL.md when working with tina4-js frontend code. Read its referenced files in .claude/skills/tina4-js/references/ as needed.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ from tina4_python.core.router import get, post, noauth
 @get("/api/users")
 async def list_users(request, response):
     from src.orm.User import User
-    return response(User().select(limit=100).to_array())
+    return response(User.select(limit=100))
 
 @get("/api/users/{id:int}")
 async def get_user(id, request, response):
@@ -288,7 +288,7 @@ Render it from a route:
 @get("/")
 async def home(request, response):
     from src.orm.User import User
-    users = User().select(limit=20).to_array()
+    users = [u.to_dict() for u in User.select(limit=20)]
     return response.render("pages/home.twig", {"title": "Users", "users": users})
 ```
 
@@ -467,7 +467,7 @@ Auto-generated at `/swagger`:
 @tags(["users"])
 @get("/api/users")
 async def users(request, response):
-    return response(User().select().to_array())
+    return response(User.select())
 ```
 
 ### Event System
@@ -629,7 +629,7 @@ profile = user.has_one("Profile", "user_id")
 customer = order.belongs_to("Customer", "customer_id")
 
 # Eager loading with include=
-users = User().select(include=["orders", "profile"])
+users = User.select(include=["orders", "profile"])
 ```
 
 ### DB Query Caching

--- a/tests/test_ai_skill_install.py
+++ b/tests/test_ai_skill_install.py
@@ -1,0 +1,31 @@
+"""`tina4 ai` must install the actual SKILL files (project + global), not just a
+CLAUDE.md pointer. Real network fetch from the release tag, no mocks."""
+import os
+
+from tina4_python.ai import install_skills, _skill_block, _DEV_SKILL
+
+
+def test_install_skills_lands_in_project_and_global(tmp_path):
+    # Pin to a tag known to carry the split skills so the test is deterministic.
+    os.environ["TINA4_SKILLS_REF"] = "3.13.59"
+    proj_skills = tmp_path / "proj" / ".claude" / "skills"
+    global_skills = tmp_path / "home" / ".claude" / "skills"
+
+    installed = install_skills(root=str(tmp_path / "proj"),
+                               targets=[proj_skills, global_skills])
+
+    assert set(installed) == {_DEV_SKILL, "tina4-js", "tina4-maintainer"}
+    for dest in (proj_skills, global_skills):
+        for skill in (_DEV_SKILL, "tina4-js", "tina4-maintainer"):
+            assert (dest / skill / "SKILL.md").exists(), f"{skill}/SKILL.md missing in {dest}"
+        # a reference file came down too
+        assert (dest / _DEV_SKILL / "references" / "data-and-orm.md").exists()
+
+    body = (proj_skills / _DEV_SKILL / "SKILL.md").read_text()
+    assert "The Tina4 Working Method" in body  # the real 3.13.59 content
+
+
+def test_claude_skill_block_uses_split_skill_name():
+    block = _skill_block("CLAUDE.md")
+    assert _DEV_SKILL in block                             # tina4-developer-python
+    assert "skills/tina4-developer/SKILL.md" not in block  # old pre-split name gone

--- a/tina4_python/CLAUDE.md
+++ b/tina4_python/CLAUDE.md
@@ -24,14 +24,14 @@ Every piece of repeated logic must be centralised. If two routes format a date, 
 ```python
 @get("/api/orders")
 async def list_orders(request, response):
-    orders = Order().select().to_array()
+    orders = [o.to_dict() for o in Order.select()]
     for o in orders:
         o["total"] = f"${abs(float(o['total'])):,.2f}"  # duplicated
     return response(orders)
 
 @get("/api/invoices")
 async def list_invoices(request, response):
-    invoices = Invoice().select().to_array()
+    invoices = [i.to_dict() for i in Invoice.select()]
     for i in invoices:
         i["amount"] = f"${abs(float(i['amount'])):,.2f}"  # duplicated!
     return response(invoices)
@@ -890,8 +890,8 @@ user.save()
 # Delete
 user.delete()
 
-# Query
-result = User().select(sql="name = ?", params=["Alice"], limit=10)
+# Query (WHERE fragment -> use where(); select() takes FULL SQL, not a fragment)
+result = User.where("name = ?", params=["Alice"], limit=10)
 
 # Convert to dict
 user.to_dict()
@@ -1797,7 +1797,7 @@ uv run tina4python migrate
 ```python
 @get("/api/products")
 async def list_products(request, response):
-    return response(Product().select(limit=100).to_array())
+    return response(Product.select(limit=100))
 
 @post("/api/products")
 async def create_product(request, response):

--- a/tina4_python/ai/__init__.py
+++ b/tina4_python/ai/__init__.py
@@ -36,6 +36,76 @@ AI_TOOLS = [
 ]
 
 
+# ── Skill files (the SKILL.md system) ───────────────────────────────────────
+# `tina4 ai` installs the actual skills — not just a CLAUDE.md pointer to them —
+# into BOTH the project (.claude/skills, so they travel with the repo) and the
+# user's global ~/.claude/skills (so they're available in every project). A
+# Python project needs the python developer skill plus the two shared skills;
+# all three are served from the tina4-python release tag.
+_DEV_SKILL = "tina4-developer-python"
+_SKILL_REPO = "tina4-python"
+_SKILLS = {
+    _DEV_SKILL: ["auth-and-services.md", "data-and-orm.md", "deployment.md",
+                 "routes-and-api.md", "templates-and-frontend.md", "realtime.md"],
+    "tina4-js": ["html-and-components.md", "signals-and-reactivity.md",
+                 "persistence.md", "rtc.md"],
+    "tina4-maintainer": ["cli-and-deployment.md", "frond-and-frontend.md",
+                         "routing-and-orm.md", "subsystems.md"],
+}
+
+
+def _skills_ref() -> str:
+    """Release tag to pull skills from — the installed framework version,
+    overridable with TINA4_SKILLS_REF (e.g. to test a branch)."""
+    ref = os.environ.get("TINA4_SKILLS_REF")
+    if ref:
+        return ref
+    try:
+        from tina4_python import __version__
+        return __version__
+    except Exception:
+        return "main"
+
+
+def _fetch_bytes(url: str) -> "bytes | None":
+    import urllib.error
+    import urllib.request
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            return resp.read()
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+def install_skills(root: str = ".", targets: "list[Path] | None" = None) -> list[str]:
+    """Install the Tina4 SKILL.md skills into the project AND global
+    ~/.claude/skills, fetched from the release tag matching this framework
+    version. Returns the skills fully installed. Network-dependent."""
+    ref = _skills_ref()
+    base = f"https://raw.githubusercontent.com/tina4stack/{_SKILL_REPO}/{ref}/.claude/skills"
+    if targets is None:
+        targets = [Path(root).resolve() / ".claude" / "skills",
+                   Path.home() / ".claude" / "skills"]
+    installed = []
+    for skill, refs in _SKILLS.items():
+        skill_ok = True
+        for dest in targets:
+            skill_dir = dest / skill
+            (skill_dir / "references").mkdir(parents=True, exist_ok=True)
+            data = _fetch_bytes(f"{base}/{skill}/SKILL.md")
+            if data is None:
+                skill_ok = False
+                continue
+            (skill_dir / "SKILL.md").write_bytes(data)
+            for r in refs:
+                rd = _fetch_bytes(f"{base}/{skill}/references/{r}")
+                if rd is not None:
+                    (skill_dir / "references" / r).write_bytes(rd)
+        if skill_ok:
+            installed.append(skill)
+    return installed
+
+
 def is_installed(root: str, tool: dict) -> bool:
     """Check if a tool's context file already exists."""
     return (Path(root).resolve() / tool["context_file"]).exists()
@@ -197,7 +267,7 @@ def _skill_block(context_file: str) -> str:
             "## Tina4 Skills\n\n"
             "When working on this Tina4 project, these skills give the "
             "assistant project-aware behaviour:\n\n"
-            "- **tina4-developer** — Read `.claude/skills/tina4-developer/SKILL.md` before building features.\n"
+            f"- **{_DEV_SKILL}** — Read `.claude/skills/{_DEV_SKILL}/SKILL.md` before building features.\n"
             "- **tina4-js** — Read `.claude/skills/tina4-js/SKILL.md` for frontend work.\n"
             "- **tina4-maintainer** — Read `.claude/skills/tina4-maintainer/SKILL.md` for framework-level changes.\n\n"
             "If Tina4 behaves differently from what these skills describe, that is a bug in the skill. "
@@ -208,7 +278,7 @@ def _skill_block(context_file: str) -> str:
     else:
         body = (
             "Tina4 Skills — read these files before working on this project:\n"
-            "  .claude/skills/tina4-developer/SKILL.md   (feature development)\n"
+            f"  .claude/skills/{_DEV_SKILL}/SKILL.md   (feature development)\n"
             "  .claude/skills/tina4-js/SKILL.md          (frontend / tina4-js)\n"
             "  .claude/skills/tina4-maintainer/SKILL.md  (framework-level changes)\n"
             "Found a skill that disagrees with how Tina4 actually behaves? Tell the developer,\n"
@@ -367,21 +437,18 @@ def _install_claude_skills(root: Path) -> list[str]:
                 rel = str(target.relative_to(root))
                 created.append(rel)
 
-    # Copy skill directories from framework .claude/skills/
-    framework_root = pkg_dir.parent
-    framework_skills_dir = framework_root / ".claude" / "skills"
-    if framework_skills_dir.is_dir():
-        target_skills_dir = root / ".claude" / "skills"
-        target_skills_dir.mkdir(parents=True, exist_ok=True)
-        for skill_dir in framework_skills_dir.iterdir():
-            if skill_dir.is_dir():
-                target_dir = target_skills_dir / skill_dir.name
-                if target_dir.exists():
-                    shutil.rmtree(target_dir)
-                shutil.copytree(skill_dir, target_dir)
-                rel = str(target_dir.relative_to(root))
-                created.append(rel)
-                print(f"  \033[32m✓\033[0m Updated {rel}")
+    # Install the SKILL.md skills into the project AND the user's global
+    # ~/.claude/skills, fetched from the release tag matching this framework
+    # version. (The previous code copied from framework_root/.claude/skills,
+    # which exists only in a dev/editable checkout — NOT in an installed pip
+    # package, where .claude/skills sits outside the tina4_python package and
+    # is never shipped. So installed users got no skills at all.)
+    for skill in install_skills(str(root)):
+        created.append(f".claude/skills/{skill}/")
+        try:
+            print(f"  \033[32m✓\033[0m Installed .claude/skills/{skill}  (project + global)")
+        except UnicodeEncodeError:
+            print(f"  [OK] Installed .claude/skills/{skill} (project + global)")
 
     return created
 


### PR DESCRIPTION
Two fixes for 3.13.60:

**1. ORM doc bug (grounding remediation).** `Model().select(...).to_array()` in README.md + tina4_python/CLAUDE.md raised `AttributeError` (select/all/where return a plain list). Corrected to `response(Model.select(...))` / `[m.to_dict() for m in Model.select(...)]`, class form. This is what `tina4_context` served as authoritative — a real bug was filed via `tina4_bug`. Verified with a real SQLite boot-gate. The neemee corpus is already re-staged + reindexed live.

**2. `tina4 ai` skill install.** It copied skills from `framework_root/.claude/skills` (absent in pip installs) → installed users got zero skill files. Now network-fetches the split skills into BOTH project + global `.claude/skills`. Real test covers both destinations.

Version bump → 3.13.60 + tag to follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)