### PR TITLE
context: native zero-dep FTS5 code/doc grounding subsystem (MVP, python)

### DIFF
--- a/.claude/skills/tina4-developer-python/SKILL.md
+++ b/.claude/skills/tina4-developer-python/SKILL.md
@@ -164,15 +164,17 @@ whenever the dev server is running (`tina4 serve` with `TINA4_DEBUG=true`):
 - **`api_search("render template")`** — ranked search across framework + your own code; returns fqn, signature, file:line. Run it BEFORE assuming a method exists.
 - **`api_class("Frond")`** — every method on a class, with signatures. A bare name (`Frond`), an import path, or the full fqn all resolve.
 - **`api_method("Frond", "add_test")`** — exact signature, params, return type, file and line for one method.
+- **`code_search("where is the auth token issued?")`** — fuzzy/semantic full-text search over **THIS project's own source + docs** (the native `Context` FTS5 index — zero-dep, kept live on every file save). Ranks the file that *defines* a symbol above tests that merely mention it. The in-repo, semantic counterpart to `api_*`.
 
 ```
 api_search("queue consume")     -> finds Queue.consume and its signature
 api_class("Database")           -> every method on Database, with signatures
 api_method("Frond", "add_test") -> add_test(name, fn)
+code_search("send an email")    -> the routes/services in YOUR app that already do it
 ```
 
 - **Unsure of a name or signature? Look it up — don't recall it.** A 5-second `api_method` call beats a hallucinated method that costs 20 minutes of debugging.
-- **`api_*` is live reflection (exact code); `docs_search` searches the prose docs.** Use `api_*` for signatures, `docs_search` for "how do I X" guidance.
+- **The grounding ladder — pick the tool by the question.** `api_*` = *exact structure* ("what's the signature of X?"); `code_search` = *semantic, in your own repo* ("where/how is X done in THIS app?"); `docs_search` = the prose docs; `tina4_context` = the current framework API + idioms (external corpus, for framework facts not in your project).
 - If `api_search`/`api_class` returns nothing for a name you expected, it probably **does not exist** in this version — tell the developer rather than inventing it.
 
 ## Quick Start

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ test_queue*.db
 /publish.sh
 /src/scss/
 /broken
+# Framework runtime artefacts under .tina4/ — the Context FTS5 index
+# (.tina4/context.db), agent.log, and file-write backups. Transient,
+# per-machine, never source-of-truth. Keep the whole dir out of git.
+/.tina4/
 # Framework runtime artefacts — BrokenTracker writes import-time and
 # route-time failure dumps here. They're transient (timestamped per
 # error) and contain stack traces, never source-of-truth content.

--- a/plan/context-subsystem.md
+++ b/plan/context-subsystem.md
@@ -1,0 +1,88 @@
+# Task: native `Context` subsystem — code/doc grounding inside Tina4
+
+**Branch:** `v3`. **Reference:** Python; port to PHP/Ruby/Node.
+**Status: APPROVED — build MVP in tina4-python first (2026-07-09), then parity. Build after the
+unified harness pod lands (see aatos `aatos-code/deploy/harness-pod/plan.md`).**
+
+**Locked decisions (2026-07-09):** MVP = tina4-python only first · on-disk portable index (Q3 →
+`.tina4/context.db` gitignored, not `:memory:`) · dense rerank OFF by default (Q4 zero-dep line held
+via `veclite`) · keep `code_search` distinct from `api_*` (Q6 → structural vs semantic).
+
+## Goal
+Ship a first-class Tina4 subsystem that indexes an app's own codebase + docs and answers
+semantic/keyword queries over it — so a Tina4 app can **ground its own AI assistant on its own
+code, offline, ~zero-dep** — with the index kept fresh **automatically on file change**, and
+exposed to agents via the dev MCP.
+
+## Context / validation (already done — spike proof)
+neemee's retrieval core is **~994 LOC of pure stdlib** (pipeline+memory+encoders+spans; `PIL`/
+`pystray` are tray-UI only). Spike (`scratchpad/neemee_spike.py`): `Neemee()` default backend =
+`sqlite_fts` (stdlib `sqlite3` FTS, no embedder) **indexed `tina4_python/` → 1000 chunks in 0.57s**
+and retrieved the right subsystem on 4/4 queries (`orm/model.py`, `queue/__init__.py`,
+`auth/__init__.py`, `frond/FROND.md`) at **7–11 ms**. Passes the reuse ladder: it **complements**
+the existing `api_*` reflection index (structured/exact) with semantic/FTS retrieval (fuzzy).
+
+## Scope
+- [x] **`tina4_python/context/`** — ported the neemee core (chunkers + `sqlite_fts` backend) as a
+      zero-dep `Context` class. API landed per the MVP task brief (not the earlier sketch): `Context(path)`,
+      `index_path(file, label=None)`, `index_root(root)`, `search(query, k=5) → [{path, score, snippet}]`.
+      Files: `tina4_python/context/__init__.py` (Context), `tina4_python/context/chunker.py` (fold/terms/
+      chunk_code/chunk_text). FTS5 schema `chunks(cid, path, raw UNINDEXED, body)`; `bm25()` ranking.
+- [~] **Incremental reindex on file-change** — `index_path()` IS the UPSERT (delete-by-path + re-chunk +
+      insert), verified sub-100ms and non-duplicating by real tests. NOT wired to a watcher: the dev
+      hot-reload is **mtime-poll on `/__dev/api/reload`** (`core/router.py::_auto_discover`), not an
+      event watcher with per-file callbacks — no clean hook exists, so per the no-invent rule the method
+      is exposed for a follow-up to call. `code_search` also lazy-rebuilds on demand (`rebuild=True`).
+- [x] **Dev-MCP `code_search` tool** — registered as a sibling of `api_search` in
+      `tina4_python/mcp/tools.py` (handler + entry in the `tools` list). Docstring + list description
+      state the split: `api_*` = exact structural lookup, `code_search` = fuzzy/semantic over source+docs.
+- [ ] **Skills** — document `code_search` + fold it into the grounding ladder: rung 1 skill →
+      rung 2 `api_*` (structural) / `code_search` (semantic, in-repo) → `tina4_context` (external corpus).
+- [ ] **Optional dense rerank** — `TINA4_CONTEXT_RERANK=dense` + an embed endpoint for the accuracy
+      uplift (router got ~82%→95% with it). Now **numpy-free** (stdlib `veclite` — dot/normalize/
+      argsort in pure Python): it adds **no** language dependency, only needs an embed endpoint at
+      runtime. OFF by default (opt-in) — but zero-dep holds even with it on.
+- [ ] Port to PHP (PDO SQLite FTS5) / Ruby (sqlite3 FTS5) / Node (better-sqlite3 FTS5) — parity.
+
+## Parity
+| Item | Python | PHP | Ruby | Node |
+|------|--------|-----|------|------|
+| `Context` core (stdlib FTS) | ❌ BUILD | ❌ | ❌ | ❌ |
+| reindex-on-change | ❌ BUILD | ❌ | ❌ | ❌ |
+| dev-MCP `code_search` | ❌ BUILD | ❌ | ❌ | ❌ |
+| optional dense rerank | ❌ BUILD | ❌ | ❌ | ❌ |
+
+## Design decisions / open questions (need the maintainer's call)
+1. **The `1000` in the spike is suspiciously round** — likely a default chunk cap in the backend. Confirm; make configurable; must scale to a large repo.
+   → RESOLVED for the native `Context`: there is **no** chunk cap; `index_root` indexes every eligible
+   file. The spike's 1000 was a harness default, not a `Context` limit.
+2. **Chunking** — reuse neemee's split (code by def/class boundary; docs by sentence — the fixed `_SENT` rule). Ship the fix, not the mangling.
+   → DONE in `chunker.py`: `chunk_code` (def/class boundaries, `# file:` header for path-token search)
+   + `chunk_text` (`_SENT` boundary, no bare-`.` shredding). Config/YAML/Dockerfiles go through the
+   line-window code chunker (sentence chunking shreds them).
+3. **Index location** — a SQLite file under `data/` (gitignored), rebuilt on boot, upserted on change. Or `:memory:` in dev for zero disk?
+   → RESOLVED per the locked decision: on-disk portable index at `.tina4/context.db` (added `/.tina4/`
+   to `.gitignore`); `Context(path)` takes any path, so `:memory:` remains available for tests/ephemeral.
+4. **Zero-dep line** — FTS core ships stdlib on Python/PHP/Ruby; Node already carries `better-sqlite3` (its one accepted dep). Dense rerank is the only thing that adds a dep, and it's opt-in. Hold that line.
+5. **Scope vs budget** — ~1000 LOC/lang against the ~5000 target. Does a code-context engine earn a 20% budget bump, or stay an optional module (not in the default dist)?
+6. **Overlap with `api_*`** — keep them distinct (structural vs semantic), or unify behind one `search`?
+
+## Tests (real, no mocks — positive + negative, per backend)
+`tests/test_context.py` — 9 tests, REAL temp SQLite files + REAL temp source trees, no mocks.
+Run: `.venv/bin/python -m pytest tests/test_context.py -v` → **9 passed**.
+- [x] index a temp code tree → `search(q)` returns the defining source file ABOVE a test that merely
+      mentions the symbol (source-over-tests + definition-first reorder over `bm25()`).
+- [x] reindex-on-change: modify a file → new content retrievable AND old chunks for that file gone,
+      with no row duplication (UPSERT = delete-by-path + insert). Plus: re-index unchanged file ≠ append.
+- [x] FTS5 guard: real `Context.fts5_available()` is True here; a Context that finds FTS5 absent
+      degrades to safe no-ops (index → 0, search → []) instead of crashing.
+- [x] result shape `{path, score, snippet}` + score descending; docs indexed as prose; vendor/build
+      dirs skipped; empty/stopword query → []. `code_search` MCP tool registered + finds a known symbol
+      in a real temp project.
+- [ ] parity output shape across PHP/Ruby/Node backends — deferred to the parity task.
+
+## Bugs
+- (none found in this MVP)
+
+## Commits
+- (pending — see git log for the `context: ...` commit on branch v3)

--- a/plan/context-subsystem.md
+++ b/plan/context-subsystem.md
@@ -28,11 +28,15 @@ the existing `api_*` reflection index (structured/exact) with semantic/FTS retri
       `index_path(file, label=None)`, `index_root(root)`, `search(query, k=5) → [{path, score, snippet}]`.
       Files: `tina4_python/context/__init__.py` (Context), `tina4_python/context/chunker.py` (fold/terms/
       chunk_code/chunk_text). FTS5 schema `chunks(cid, path, raw UNINDEXED, body)`; `bm25()` ranking.
-- [~] **Incremental reindex on file-change** — `index_path()` IS the UPSERT (delete-by-path + re-chunk +
-      insert), verified sub-100ms and non-duplicating by real tests. NOT wired to a watcher: the dev
-      hot-reload is **mtime-poll on `/__dev/api/reload`** (`core/router.py::_auto_discover`), not an
-      event watcher with per-file callbacks — no clean hook exists, so per the no-invent rule the method
-      is exposed for a follow-up to call. `code_search` also lazy-rebuilds on demand (`rebuild=True`).
+- [x] **Incremental reindex on file-change — WIRED to the dev WebSocket-reload trigger.** `POST
+      /__dev/api/reload` (`dev_admin._api_reload`, the same handler that broadcasts the instant reload
+      over the `/__dev_reload` WebSocket) now calls `Context.reindex_file(changed_file)` after
+      `_auto_discover`, so a saved file is reindexed (UPSERT) and searchable immediately — no rebuild.
+      `Context` + `code_search` share ONE process-wide index (`context.default_context` /
+      `existing_context`) so the hook keeps the same index `code_search` reads. `reindex_file` resolves
+      the project-root-relative path the trigger reports against the index root (may be `src/`),
+      handles deletes (drop rows), and skips outside-root / skip-dir / ineligible files. Guarded so a
+      context failure never breaks the reload. Real end-to-end test drives `_api_reload` → search.
 - [x] **Dev-MCP `code_search` tool** — registered as a sibling of `api_search` in
       `tina4_python/mcp/tools.py` (handler + entry in the `tools` list). Docstring + list description
       state the split: `api_*` = exact structural lookup, `code_search` = fuzzy/semantic over source+docs.
@@ -47,9 +51,9 @@ the existing `api_*` reflection index (structured/exact) with semantic/FTS retri
 ## Parity
 | Item | Python | PHP | Ruby | Node |
 |------|--------|-----|------|------|
-| `Context` core (stdlib FTS) | ❌ BUILD | ❌ | ❌ | ❌ |
-| reindex-on-change | ❌ BUILD | ❌ | ❌ | ❌ |
-| dev-MCP `code_search` | ❌ BUILD | ❌ | ❌ | ❌ |
+| `Context` core (stdlib FTS) | ✅ | ❌ | ❌ | ❌ |
+| reindex-on-change (WS-reload trigger) | ✅ | ❌ | ❌ | ❌ |
+| dev-MCP `code_search` | ✅ | ❌ | ❌ | ❌ |
 | optional dense rerank | ❌ BUILD | ❌ | ❌ | ❌ |
 
 ## Design decisions / open questions (need the maintainer's call)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,232 @@
+"""Real, no-mock tests for the native ``Context`` code/doc grounding subsystem.
+
+Every test uses a REAL temp SQLite file (``tmp_path``) and REAL temp source
+files — there is nothing to mock. They pin the four behaviours the MVP promises:
+
+1. ranking: a definition out-ranks a test that merely mentions the symbol
+   (source-over-tests + definition-first reorder over ``bm25()``);
+2. reindex-on-change: ``index_path`` is an UPSERT — new content is found and
+   the file's old chunks are gone, with no row duplication;
+3. FTS5 availability guard: detected for real, and a Context that finds FTS5
+   absent degrades to safe no-ops instead of crashing;
+4. result shape + the dev-MCP ``code_search`` tool over a real temp project.
+"""
+
+import json
+import os
+
+import pytest
+
+from tina4_python.context import Context
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _write(root, rel, body):
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# --------------------------------------------------------------------------- #
+# 1. ranking — definition above a test that mentions the symbol
+# --------------------------------------------------------------------------- #
+def test_definition_outranks_test_that_mentions_symbol(tmp_path):
+    src_root = tmp_path / "app"
+    _write(src_root, "src/auth.py",
+           "def get_token(user):\n"
+           "    '''issue an auth token for a user'''\n"
+           "    return _sign(user)\n")
+    # a test file that MENTIONS get_token many times (BM25 loves this) but
+    # does not DEFINE it — it must not out-rank the definition.
+    _write(src_root, "tests/test_auth.py",
+           "def test_get_token():\n"
+           "    assert get_token(1)\n"
+           "    assert get_token(2)\n"
+           "    assert get_token(3)\n"
+           "    assert get_token(4)\n")
+
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    n = ctx.index_root(src_root)
+    assert n > 0
+
+    res = ctx.search("get_token", k=5)
+    paths = [r["path"] for r in res]
+    # both files surface
+    assert any(p.endswith("auth.py") and "test" not in p for p in paths), paths
+    assert any("test_auth" in p for p in paths), paths
+    # the definition (non-test source) ranks ABOVE the test file
+    src_idx = next(i for i, r in enumerate(res)
+                   if r["path"].endswith("auth.py") and "test" not in r["path"])
+    test_idx = next(i for i, r in enumerate(res) if "test_auth" in r["path"])
+    assert src_idx < test_idx, f"definition should out-rank the test: {paths}"
+    # and the very top hit is the definition, not the test
+    assert "test" not in res[0]["path"], paths
+    ctx.close()
+
+
+# --------------------------------------------------------------------------- #
+# 2. reindex-on-change — UPSERT: new found, old gone, no duplication
+# --------------------------------------------------------------------------- #
+def test_reindex_on_change_is_upsert(tmp_path):
+    src_root = tmp_path / "app"
+    f = _write(src_root, "src/mod.py", "def alpha():\n    return 1\n")
+
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    ctx.index_path(f, label="src/mod.py")
+
+    assert any(r["path"] == "src/mod.py" for r in ctx.search("alpha")), "alpha should be found first"
+    rows_before = ctx.count()
+
+    # edit the file: alpha -> beta, then re-index just this file
+    f.write_text("def beta():\n    return 2\n", encoding="utf-8")
+    ctx.index_path(f, label="src/mod.py")
+
+    # new content retrievable
+    assert any(r["path"] == "src/mod.py" for r in ctx.search("beta")), "beta should be found after reindex"
+    # OLD content for this file is gone (upsert deleted the stale chunks)
+    assert not any(r["path"] == "src/mod.py" for r in ctx.search("alpha")), "alpha chunks must be gone"
+    # no duplication — same file, same chunk count => same total rows
+    assert ctx.count() == rows_before, "UPSERT must delete-then-insert, not append"
+    ctx.close()
+
+
+def test_index_path_second_call_replaces_not_appends(tmp_path):
+    """Indexing the SAME unchanged file twice must not double its rows."""
+    src_root = tmp_path / "app"
+    f = _write(src_root, "src/dup.py", "def only_one():\n    return 42\n")
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    ctx.index_path(f, label="src/dup.py")
+    n1 = ctx.count()
+    ctx.index_path(f, label="src/dup.py")
+    assert ctx.count() == n1, "re-indexing an unchanged file must not append duplicates"
+    ctx.close()
+
+
+# --------------------------------------------------------------------------- #
+# 3. FTS5 availability guard
+# --------------------------------------------------------------------------- #
+def test_fts5_available_on_this_interpreter():
+    # real detector — this build of sqlite ships FTS5, so it must report True
+    assert Context.fts5_available() is True
+
+
+def test_context_degrades_gracefully_without_fts5(tmp_path):
+    src_root = tmp_path / "app"
+    _write(src_root, "src/x.py", "def y():\n    return 1\n")
+
+    # inject a predicate that reports FTS5 as ABSENT — exercises the real
+    # graceful-degradation branch (no mocking of sqlite or files).
+    ctx = Context(tmp_path / ".tina4" / "context.db", fts5_check=lambda: False)
+    assert ctx.available is False
+    assert ctx.index_root(src_root) == 0
+    assert ctx.index_path(src_root / "src" / "x.py", label="src/x.py") == 0
+    assert ctx.search("anything") == []
+    ctx.close()
+
+    # a normal Context on this interpreter IS available
+    ok = Context(tmp_path / ".tina4" / "ok.db")
+    assert ok.available is True
+    ok.close()
+
+
+# --------------------------------------------------------------------------- #
+# 4. result shape, score ordering, doc chunking, dir skipping
+# --------------------------------------------------------------------------- #
+def test_search_result_shape_and_score_ordering(tmp_path):
+    src_root = tmp_path / "app"
+    _write(src_root, "src/widget.py",
+           "def build_widget(spec):\n    return Widget(spec)\n\n"
+           "class Widget:\n    pass\n")
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    ctx.index_root(src_root)
+
+    res = ctx.search("build_widget", k=5)
+    assert res, "expected at least one hit"
+    for r in res:
+        assert set(r) >= {"path", "score", "snippet"}, r
+        assert isinstance(r["score"], float)
+        assert isinstance(r["snippet"], str) and r["snippet"]
+    # higher score = better; results are sorted descending
+    scores = [r["score"] for r in res]
+    assert scores == sorted(scores, reverse=True), scores
+    ctx.close()
+
+
+def test_indexes_docs_as_prose_and_skips_vendor_dirs(tmp_path):
+    src_root = tmp_path / "app"
+    _write(src_root, "docs/guide.md",
+           "# Overview\n\nThe whirligig subsystem manages the flux capacitor "
+           "and its temporal bindings.\n")
+    # these live under dirs neemee skips — they must NOT be indexed
+    _write(src_root, "__pycache__/junk.py", "def whirligig_flux_capacitor(): pass\n")
+    _write(src_root, "node_modules/lib.js", "function whirligigFluxCapacitor(){}\n")
+
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    ctx.index_root(src_root)
+
+    res = ctx.search("whirligig flux capacitor", k=5)
+    paths = [r["path"] for r in res]
+    assert any(p.endswith("guide.md") for p in paths), paths
+    assert not any("__pycache__" in p for p in paths), paths
+    assert not any("node_modules" in p for p in paths), paths
+    ctx.close()
+
+
+def test_empty_or_stopword_query_returns_empty(tmp_path):
+    src_root = tmp_path / "app"
+    _write(src_root, "src/a.py", "def a():\n    return 1\n")
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    ctx.index_root(src_root)
+    assert ctx.search("") == []
+    assert ctx.search("   ") == []
+    ctx.close()
+
+
+# --------------------------------------------------------------------------- #
+# 5. dev-MCP `code_search` tool — real registration over a temp project
+# --------------------------------------------------------------------------- #
+class TestCodeSearchTool:
+    def _server_in(self, project_dir):
+        from tina4_python.mcp import McpServer
+        from tina4_python.mcp.tools import register_dev_tools
+        server = McpServer("/test-code-search", name="code_search test")
+        register_dev_tools(server)
+        return server
+
+    def _call(self, server, name, arguments=None):
+        return json.loads(server.handle_message({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": name, "arguments": arguments or {}},
+        }))
+
+    def test_code_search_registered_and_finds_symbol(self, tmp_path):
+        # real temp Tina4-ish project
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "service.py").write_text(
+            "def widget_factory(name):\n"
+            "    '''create a configured widget'''\n"
+            "    return {'name': name}\n",
+            encoding="utf-8",
+        )
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            server = self._server_in(tmp_path)
+            # tool is registered (sibling of api_search)
+            listed = json.loads(server.handle_message({
+                "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {},
+            }))
+            names = {t["name"] for t in listed["result"]["tools"]}
+            assert "code_search" in names, names
+
+            resp = self._call(server, "code_search", {"query": "widget_factory"})
+            assert "result" in resp, resp
+            payload = json.loads(resp["result"]["content"][0]["text"])
+            assert isinstance(payload, list), payload
+            paths = [r["path"] for r in payload]
+            assert any(p.endswith("service.py") for p in paths), payload
+        finally:
+            os.chdir(old_cwd)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -186,6 +186,109 @@ def test_empty_or_stopword_query_returns_empty(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# 5. reindex-on-change — reindex_file UPSERT against the index root
+# --------------------------------------------------------------------------- #
+def test_reindex_file_upserts_against_a_subdir_root(tmp_path):
+    """The reload trigger reports project-root-relative paths ('src/mod.py'),
+    but the index root may be a subdir (src/); reindex_file must relabel and
+    upsert correctly."""
+    _write(tmp_path, "src/mod.py", "def wombat():\n    return 1\n")
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    ctx.index_root(tmp_path / "src")                 # root = src/, label = "mod.py"
+    assert any(r["path"] == "mod.py" for r in ctx.search("wombat"))
+
+    (tmp_path / "src" / "mod.py").write_text("def giraffe():\n    return 2\n", encoding="utf-8")
+    old = os.getcwd(); os.chdir(tmp_path)
+    try:
+        assert ctx.reindex_file("src/mod.py") >= 1   # project-root-relative path
+    finally:
+        os.chdir(old)
+    assert any(r["path"] == "mod.py" for r in ctx.search("giraffe")), "new content found"
+    assert not any(r["path"] == "mod.py" for r in ctx.search("wombat")), "old content gone"
+    ctx.close()
+
+
+def test_reindex_file_skips_outside_root_ineligible_and_skipdirs(tmp_path):
+    _write(tmp_path, "src/a.py", "def a():\n    return 1\n")
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    ctx.index_root(tmp_path / "src")
+    old = os.getcwd(); os.chdir(tmp_path)
+    try:
+        _write(tmp_path, "README.md", "# top-level, outside src/\n")
+        assert ctx.reindex_file("README.md") == -1        # outside the index root
+        _write(tmp_path, "src/data.bin", "x")
+        assert ctx.reindex_file("src/data.bin") == -1      # ineligible extension
+        _write(tmp_path, "src/__pycache__/j.py", "def j(): pass\n")
+        assert ctx.reindex_file("src/__pycache__/j.py") == -1   # skip-dir
+    finally:
+        os.chdir(old)
+    ctx.close()
+
+
+def test_reindex_file_drops_a_deleted_file(tmp_path):
+    f = _write(tmp_path, "src/gone.py", "def unique_gone_sym():\n    return 1\n")
+    ctx = Context(tmp_path / ".tina4" / "context.db")
+    ctx.index_root(tmp_path / "src")
+    assert any(r["path"] == "gone.py" for r in ctx.search("unique_gone_sym"))
+    f.unlink()
+    old = os.getcwd(); os.chdir(tmp_path)
+    try:
+        assert ctx.reindex_file("src/gone.py") == 0        # delete → drop rows
+    finally:
+        os.chdir(old)
+    assert ctx.search("unique_gone_sym") == [], "deleted file's chunks must be gone"
+    ctx.close()
+
+
+def test_default_context_is_a_shared_singleton(tmp_path):
+    from tina4_python.context import default_context, existing_context, _shared_contexts
+    _shared_contexts.clear()
+    db = tmp_path / ".tina4" / "ctx.db"
+    _write(tmp_path, "src/x.py", "def findme_sym():\n    return 1\n")
+    a = default_context(root=tmp_path / "src", db=db)
+    assert a is default_context(db=db), "same db path → same instance"
+    assert existing_context(db=db) is a
+    assert existing_context(db=tmp_path / "nope.db") is None
+    assert any("x.py" in r["path"] for r in a.search("findme_sym"))
+    a.close(); _shared_contexts.clear()
+
+
+# --------------------------------------------------------------------------- #
+# 6. the dev WebSocket-reload TRIGGER reindexes the changed file end-to-end
+# --------------------------------------------------------------------------- #
+class TestReloadReindex:
+    def test_api_reload_reindexes_changed_file(self, tmp_path):
+        """POST /__dev/api/reload (the WebSocket reload trigger) must reindex the
+        changed file into the shared Context so code_search reflects the edit."""
+        import asyncio
+        from tina4_python.context import default_context, _shared_contexts
+        import tina4_python.dev_admin as dev
+
+        _shared_contexts.clear()
+        src = tmp_path / "src"; src.mkdir(parents=True)
+        (src / "mod.py").write_text("def wombat():\n    return 1\n", encoding="utf-8")
+
+        old = os.getcwd(); os.chdir(tmp_path)
+        try:
+            # build the shared index the way code_search does (cwd/.tina4/context.db)
+            ctx = default_context(root=src)
+            assert any(r["path"] == "mod.py" for r in ctx.search("wombat"))
+
+            # edit, then FIRE the reload trigger with the changed file (real request obj)
+            (src / "mod.py").write_text("def giraffe():\n    return 2\n", encoding="utf-8")
+            req = type("Req", (), {"body": {"file": "src/mod.py", "type": "reload"}, "params": {}})()
+            asyncio.run(dev._api_reload(req, lambda payload=None, *a, **k: payload))
+
+            assert any(r["path"] == "mod.py" for r in ctx.search("giraffe")), \
+                "the reload trigger must reindex the new content"
+            assert not any(r["path"] == "mod.py" for r in ctx.search("wombat")), \
+                "old content must be gone after the reload reindex"
+        finally:
+            os.chdir(old)
+            _shared_contexts.clear()
+
+
+# --------------------------------------------------------------------------- #
 # 5. dev-MCP `code_search` tool — real registration over a temp project
 # --------------------------------------------------------------------------- #
 class TestCodeSearchTool:

--- a/tina4_python/context/__init__.py
+++ b/tina4_python/context/__init__.py
@@ -37,7 +37,7 @@ from .chunker import (
     terms,
 )
 
-__all__ = ["Context"]
+__all__ = ["Context", "default_context", "existing_context"]
 
 # File classification — mirrors neemee's repo walk.
 CODE_EXTS = {".py", ".php", ".js", ".mjs", ".ts", ".rb",
@@ -102,6 +102,7 @@ class Context:
         self.path = str(path)
         self._lock = threading.Lock()
         self.conn = None
+        self.root = None            # set by index_root; reindex_file relabels against it
         check = fts5_check or _fts5_supported
         self.available = bool(check())
         if not self.available:
@@ -179,29 +180,68 @@ class Context:
             self.conn.commit()
         return len(rows)
 
+    @staticmethod
+    def _eligible(filename) -> bool:
+        """True if a file should be indexed (the per-file filter used by both
+        index_root and reindex_file). Directory skipping is handled separately."""
+        fn = filename.lower()
+        if fn.endswith(".min.js"):
+            return False
+        ext = os.path.splitext(fn)[1]
+        return (ext in CODE_EXTS or ext in DOC_EXTS or ext in CONFIG_EXTS
+                or fn in SPECIAL_FILES)
+
     def index_root(self, root) -> int:
         """Walk ``root``, indexing every eligible file (skips vendor/build/
         runtime dirs). Paths are stored RELATIVE to ``root`` for clean
-        citations. Returns the total number of chunks inserted."""
+        citations. Records ``root`` so reindex_file can relabel a changed file
+        consistently. Returns the total number of chunks inserted."""
         if not self.available:
             return 0
         root = Path(root).resolve()
+        self.root = root
         total = 0
         for dirpath, dirnames, filenames in os.walk(root):
             # prune skip-dirs and dotdirs in place
             dirnames[:] = [d for d in dirnames
                            if d not in SKIP_DIRS and not d.startswith(".")]
             for fn in sorted(filenames):
-                ext = os.path.splitext(fn)[1].lower()
-                special = fn.lower() in SPECIAL_FILES
-                if (ext not in CODE_EXTS and ext not in DOC_EXTS
-                        and ext not in CONFIG_EXTS and not special) \
-                        or fn.endswith(".min.js"):
+                if not self._eligible(fn):
                     continue
                 full = Path(dirpath) / fn
                 rel = str(full.relative_to(root))
                 total += self.index_path(full, label=rel)
         return total
+
+    def reindex_file(self, changed_path) -> int:
+        """Re-index a single changed file into the LIVE index — the hook the dev
+        WebSocket reload trigger (POST /__dev/api/reload) calls so code_search
+        tracks edits without a rebuild. Resolves ``changed_path`` against the
+        indexed root, then: outside root / under a skip-or-dot dir / ineligible
+        → skip (-1); deleted → drop its chunks (0); otherwise UPSERT (rows).
+        No-op (-1) until index_root has run (nothing to keep fresh yet)."""
+        if not self.available or self.root is None:
+            return -1
+        p = Path(changed_path)
+        if not p.is_absolute():
+            # the reload trigger reports paths relative to the project root (cwd
+            # during `tina4 serve`); the index root may be a subdir like src/.
+            p = Path.cwd() / changed_path
+        try:
+            rel = p.resolve().relative_to(self.root)
+        except (ValueError, OSError):
+            return -1                          # outside the indexed root
+        if set(rel.parts) & SKIP_DIRS or any(part.startswith(".") for part in rel.parts[:-1]):
+            return -1                          # under a skipped / dot dir
+        if not self._eligible(rel.name):
+            return -1
+        stored = str(rel)
+        if not p.exists():                     # deleted → drop its chunks
+            with self._lock:
+                self.conn.execute("DELETE FROM chunks WHERE path = ?", (stored,))
+                self.conn.commit()
+            return 0
+        return self.index_path(p, label=stored)
 
     # ── query ───────────────────────────────────────────────────
     def _match_expr(self, query):
@@ -297,3 +337,35 @@ class Context:
             with self._lock:
                 self.conn.close()
                 self.conn = None
+
+
+# ── process-wide shared index ───────────────────────────────────
+# code_search (dev MCP) and the dev-reload reindex hook must share ONE index so
+# a saved file is immediately searchable. Keyed by resolved db path.
+_shared_contexts: dict = {}
+
+
+def _db_key(db=None) -> str:
+    return str((Path(db) if db else Path.cwd() / ".tina4" / "context.db").resolve())
+
+
+def default_context(root=None, db=None) -> "Context":
+    """Get (or create) the process-wide Context at ``db`` (default
+    ``<cwd>/.tina4/context.db``). If ``root`` is given and the index is empty,
+    builds it once. This is what code_search uses so the reload hook can keep
+    the SAME index fresh."""
+    key = _db_key(db)
+    ctx = _shared_contexts.get(key)
+    if ctx is None:
+        ctx = Context(key)
+        _shared_contexts[key] = ctx
+    if root is not None and ctx.available and ctx.is_empty():
+        ctx.index_root(root)
+    return ctx
+
+
+def existing_context(db=None):
+    """Return the already-created shared Context for ``db`` (or None). Used by
+    the reload hook so a file change reindexes an EXISTING index but never
+    creates one on its own (nothing to keep fresh until code_search runs)."""
+    return _shared_contexts.get(_db_key(db))

--- a/tina4_python/context/__init__.py
+++ b/tina4_python/context/__init__.py
@@ -1,0 +1,299 @@
+# Tina4Python
+#
+# Context — a native, zero-dependency code/doc grounding index.
+#
+# Lets a Tina4 app ground its own AI assistant on its own source, offline:
+# it walks the project, chunks code on def/class boundaries and docs as prose,
+# and answers keyword/fuzzy queries over a SQLite FTS5 index (Python stdlib
+# ``sqlite3`` — FTS5 + ``bm25()`` are built in, so NO new dependency).
+#
+# The retrieval core is a thin port of the proven slice of neemee
+# (longmem-harness: memory_systems.SqliteFTS + pipeline.retrieve's stable
+# source-over-tests / definition-first reorderings). It COMPLEMENTS the
+# ``api_*`` reflection tools: ``api_*`` is exact structural lookup, Context is
+# fuzzy/semantic FTS over source + docs.
+#
+#   from tina4_python.context import Context
+#   ctx = Context(".tina4/context.db")
+#   ctx.index_root("src")
+#   ctx.search("where is the auth token issued?", k=5)
+#   #  -> [{"path": "src/auth.py", "score": 2.31, "snippet": "..."}, ...]
+#
+# On-disk index defaults to ``.tina4/context.db`` (gitignored). Guards a
+# sqlite build without FTS5: if absent, the Context degrades to safe no-ops
+# rather than crashing the app.
+
+import os
+import re
+import sqlite3
+import threading
+from pathlib import Path
+
+from .chunker import (
+    chunk_code,
+    chunk_text,
+    fold,
+    light_stem,
+    terms,
+)
+
+__all__ = ["Context"]
+
+# File classification — mirrors neemee's repo walk.
+CODE_EXTS = {".py", ".php", ".js", ".mjs", ".ts", ".rb",
+             ".pas", ".dpr", ".dpk", ".inc", ".dfm", ".fmx"}
+DOC_EXTS = {".md", ".txt", ".rst", ".twig", ".html"}
+# deploy/CLI/env answers live in config files, not sources — chunk as code
+# (line windows), since sentence chunking shreds YAML/Dockerfiles.
+CONFIG_EXTS = {".toml", ".yml", ".yaml"}
+SPECIAL_FILES = {"dockerfile", "makefile", "docker-compose.yml",
+                 "package.json", "composer.json",
+                 ".env.example", ".env.sample"}
+# Same dirs neemee skips, plus Tina4 runtime dirs that hold no source of truth
+# (our own index/backups, session blobs, logs).
+SKIP_DIRS = {".git", "__pycache__", "node_modules", "vendor", "dist",
+             "build", "coverage", ".idea", ".venv", "venv", ".pytest_cache",
+             ".tina4", "sessions", "logs"}
+
+# generic question/code vocabulary that never NAMES a symbol — kept small.
+_DEF_STOP = frozenset(
+    "the and what how does can which where when who why list all available "
+    "module class function functions method methods def get set new return "
+    "import from with that this are is was for into use used".split())
+
+# a chunk that DEFINES a queried symbol ('def get_token', 'class Widget')
+# should out-rank one that merely USES it. Matched against the folded body.
+_DEF_KW = r"(?:async def|def|class|function|fn|func|interface|trait)"
+
+
+def _fts5_supported() -> bool:
+    """True if this interpreter's sqlite3 was built with FTS5."""
+    try:
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.execute("CREATE VIRTUAL TABLE _probe USING fts5(x)")
+            return True
+        finally:
+            conn.close()
+    except sqlite3.OperationalError:
+        return False
+    except Exception:
+        return False
+
+
+class Context:
+    """A SQLite FTS5 index over a project's source + docs.
+
+    Methods:
+        index_path(file, label=None) -> int   upsert one file (delete-by-path,
+                                               re-chunk, insert); reindex-safe.
+        index_root(root)             -> int   walk a tree, index every eligible
+                                               file (skips vendor/build dirs).
+        search(query, k=5)           -> list  [{path, score, snippet}] ranked by
+                                               bm25() with source-over-tests +
+                                               definition-first reordering.
+    """
+
+    def __init__(self, path="./.tina4/context.db", fts5_check=None):
+        """``path`` is the on-disk index file (its parent dir is created).
+        ``fts5_check`` overrides FTS5 detection (used by tests to exercise the
+        graceful-degradation path); defaults to a real probe of this build.
+        """
+        self.path = str(path)
+        self._lock = threading.Lock()
+        self.conn = None
+        check = fts5_check or _fts5_supported
+        self.available = bool(check())
+        if not self.available:
+            return
+        parent = Path(self.path).parent
+        if str(parent) not in ("", "."):
+            parent.mkdir(parents=True, exist_ok=True)
+        # One connection shared across threads (the dev-MCP handler may run on
+        # a worker thread) with a lock serializing access — a same-thread-only
+        # connection would reject those calls outright.
+        self.conn = sqlite3.connect(self.path, check_same_thread=False)
+        self._ensure_table()
+
+    # ── FTS5 availability ───────────────────────────────────────
+    @classmethod
+    def fts5_available(cls) -> bool:
+        """Whether this Python's sqlite3 supports FTS5 (module-level probe)."""
+        return _fts5_supported()
+
+    # ── schema ──────────────────────────────────────────────────
+    def _ensure_table(self):
+        # `body` holds fold(text) so query/index tokenization is symmetric;
+        # `raw` (UNINDEXED) keeps the original text to return as a snippet;
+        # `path`/`cid` (UNINDEXED) are metadata used for upsert + citation.
+        self.conn.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS chunks "
+            "USING fts5(cid UNINDEXED, path UNINDEXED, raw UNINDEXED, body)"
+        )
+        self.conn.commit()
+
+    def reset(self):
+        """Drop and recreate the index (full rebuild starting point)."""
+        if not self.available:
+            return
+        with self._lock:
+            self.conn.execute("DROP TABLE IF EXISTS chunks")
+            self._ensure_table()
+
+    # ── indexing ────────────────────────────────────────────────
+    @staticmethod
+    def _chunks_for(label, text):
+        """(index, chunk_text) pairs — code files on def/class boundaries,
+        everything else (docs) as prose."""
+        ext = os.path.splitext(label)[1].lower()
+        special = os.path.basename(label).lower() in SPECIAL_FILES
+        if ext in CODE_EXTS or ext in CONFIG_EXTS or special:
+            return chunk_code(text, path=label)
+        return chunk_text(text)
+
+    def index_path(self, file, label=None) -> int:
+        """UPSERT one file into the index: delete this path's existing chunks,
+        re-chunk the current contents, insert. A single file save re-indexes
+        just that file (sub-100ms). ``label`` is the stored/citation path
+        (defaults to ``str(file)``) and MUST be stable across calls for the
+        same file so the delete targets the right rows. Returns rows inserted.
+        """
+        if not self.available:
+            return 0
+        stored = str(label) if label is not None else str(file)
+        try:
+            text = Path(file).read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return 0
+        rows = [
+            (f"{stored}:{i}", stored, chunk, fold(chunk))
+            for i, chunk in self._chunks_for(stored, text)
+        ]
+        with self._lock:
+            self.conn.execute("DELETE FROM chunks WHERE path = ?", (stored,))
+            if rows:
+                self.conn.executemany(
+                    "INSERT INTO chunks(cid, path, raw, body) VALUES (?, ?, ?, ?)",
+                    rows,
+                )
+            self.conn.commit()
+        return len(rows)
+
+    def index_root(self, root) -> int:
+        """Walk ``root``, indexing every eligible file (skips vendor/build/
+        runtime dirs). Paths are stored RELATIVE to ``root`` for clean
+        citations. Returns the total number of chunks inserted."""
+        if not self.available:
+            return 0
+        root = Path(root).resolve()
+        total = 0
+        for dirpath, dirnames, filenames in os.walk(root):
+            # prune skip-dirs and dotdirs in place
+            dirnames[:] = [d for d in dirnames
+                           if d not in SKIP_DIRS and not d.startswith(".")]
+            for fn in sorted(filenames):
+                ext = os.path.splitext(fn)[1].lower()
+                special = fn.lower() in SPECIAL_FILES
+                if (ext not in CODE_EXTS and ext not in DOC_EXTS
+                        and ext not in CONFIG_EXTS and not special) \
+                        or fn.endswith(".min.js"):
+                    continue
+                full = Path(dirpath) / fn
+                rel = str(full.relative_to(root))
+                total += self.index_path(full, label=rel)
+        return total
+
+    # ── query ───────────────────────────────────────────────────
+    def _match_expr(self, query):
+        """Build the FTS5 MATCH string: each folded query token (plus its
+        light stem) as a quoted OR term. Quoting keeps it injection-safe."""
+        toks = set()
+        for t in terms(query):
+            toks.add(t)
+            toks.add(light_stem(t))
+        toks.discard("")
+        if not toks:
+            return None, set()
+        expr = " OR ".join('"%s"' % t for t in sorted(toks))
+        return expr, toks
+
+    @staticmethod
+    def _is_testlike(path):
+        s = (path or "").lower()
+        return any(p in s for p in ("/test", "test/", "test_", "_test.",
+                                    ".test.", "/example", "example/"))
+
+    def _defines(self, folded_body, symbols):
+        if not symbols:
+            return False
+        pat = re.compile(
+            _DEF_KW + r"\s+(?:" + "|".join(re.escape(s) for s in symbols)
+            + r")(?![a-z0-9])")
+        return bool(pat.search(folded_body))
+
+    def search(self, query, k=5):
+        """Return the top-``k`` chunks as ``[{path, score, snippet}]``, ranked
+        by ``bm25()`` then reordered with two stable, proven passes:
+          - source-over-tests: a test that merely mentions a symbol sinks below
+            the source that defines it (skipped when the query is about tests);
+          - definition-first: a chunk that DEFINES a queried symbol rises above
+            chunks that only use it.
+        Score is a higher-is-better float (sqlite's bm25 sign flipped).
+        """
+        if not self.available:
+            return []
+        expr, _ = self._match_expr(query)
+        if expr is None:
+            return []
+        pool_n = max(k * 3, 15)
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT path, raw, body, bm25(chunks) AS s FROM chunks "
+                "WHERE chunks MATCH ? ORDER BY s LIMIT ?",
+                (expr, pool_n),
+            ).fetchall()
+        if not rows:
+            return []
+
+        # candidate symbol names from the query (drop generic vocab).
+        symbols = {t for t in terms(query) if len(t) >= 3 and t not in _DEF_STOP}
+        about_tests = "test" in query.lower()
+
+        def sort_key(item):
+            idx, (path, raw, body, s) = item
+            is_test = 1 if (not about_tests and self._is_testlike(path)) else 0
+            is_def = 0 if self._defines(body, symbols) else 1
+            return (is_test, is_def, idx)   # bm25 order (idx) breaks ties
+
+        ordered = sorted(enumerate(rows), key=sort_key)
+        out = []
+        for _, (path, raw, body, s) in ordered[:k]:
+            out.append({
+                "path": path,
+                "score": round(-float(s), 6),   # bm25: more negative = better
+                "snippet": self._snippet(raw),
+            })
+        return out
+
+    @staticmethod
+    def _snippet(raw, limit=280):
+        text = (raw or "").strip()
+        if len(text) <= limit:
+            return text
+        return text[:limit].rstrip() + " ..."
+
+    # ── misc ────────────────────────────────────────────────────
+    def count(self) -> int:
+        if not self.available:
+            return 0
+        with self._lock:
+            return self.conn.execute("SELECT count(*) FROM chunks").fetchone()[0]
+
+    def is_empty(self) -> bool:
+        return self.count() == 0
+
+    def close(self):
+        if self.conn is not None:
+            with self._lock:
+                self.conn.close()
+                self.conn = None

--- a/tina4_python/context/chunker.py
+++ b/tina4_python/context/chunker.py
@@ -1,0 +1,120 @@
+# Tina4Python
+#
+# Text folding + chunking for the Context subsystem.
+#
+# A thin, idiomatic port of the proven slice of neemee's tokenizer/chunkers
+# (longmem-harness: pipeline.chunk_code / chunk_text, memory_systems.fold).
+# Pure stdlib — ``re``/``unicodedata`` only. Nothing here touches SQLite; it
+# produces the (folded body, raw text) pairs the FTS5 index stores.
+
+import re
+import unicodedata
+
+# join comma-grouped numbers ("24,601" -> "24601") and split camelCase
+# ("ForeignKeyField" -> "foreign key field") so a query token reaches a
+# code identifier. snake_case already splits for free at the tokenizer.
+_NUM_COMMA = re.compile(r"(?<=\d),(?=\d)")
+_CAMEL = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+# Sentence boundary = end punctuation FOLLOWED BY whitespace/EOL, or a newline.
+# NOT a bare '.', which would shred embedded code in prose ("db.fetch()" ->
+# "db. fetch()"). Intra-token dots (method calls, module paths) stay intact.
+_SENT = re.compile(r"(?<=[.!?])\s+|\n+")
+
+# Chunk boundaries across languages: python defs/classes/decorators, php/js
+# functions and methods, ts exports/interfaces, php traits, and Object Pascal
+# unit/type/routine headers (Delphi is case-insensitive, accept either case).
+_TOPLEVEL = re.compile(
+    r"^(async def |def |class |@\w"
+    r"|\s*(?:public |private |protected |static |final |abstract )*function \w"
+    r"|(?:export )?(?:default )?(?:abstract )?class "
+    r"|interface |trait "
+    r"|export (?:const|function|interface|type|async) "
+    r"|[Uu]nit |[Pp]rocedure |[Ff]unction |[Cc]onstructor |[Dd]estructor "
+    r"|[Tt]ype$)"
+)
+
+
+def fold(text: str) -> str:
+    """Lowercase, strip diacritics, join comma-grouped numbers, split camelCase.
+
+    Applied symmetrically to the indexed ``body`` and to query tokens so
+    matching is consistent: a query for ``field`` reaches ``IntegerField``.
+    """
+    text = _CAMEL.sub(" ", _NUM_COMMA.sub("", text)).lower()
+    return unicodedata.normalize("NFKD", text) \
+        .encode("ascii", "ignore").decode("ascii")
+
+
+def light_stem(token: str) -> str:
+    """Fold simple plurals: strip one trailing 's', never from ss/us/is
+    endings (class, status, axis). QUERY-side only — so ``fields`` in a
+    question also reaches ``Field`` definitions."""
+    if len(token) > 3 and token.endswith("s") and not token.endswith(("ss", "us", "is")):
+        return token[:-1]
+    return token
+
+
+def terms(text: str):
+    """Accent-folded lowercase alphanumeric tokens (digits kept)."""
+    return _WORD_RE.findall(fold(text))
+
+
+def _pack(segments, max_lines):
+    """Pack line-segments into chunks of at most ``max_lines`` lines,
+    hard-splitting any single oversized segment."""
+    chunks, cur = [], []
+    for seg in segments:
+        while len(seg) > max_lines:            # oversized segment: hard split
+            if cur:
+                chunks.append(cur)
+                cur = []
+            chunks.append(seg[:max_lines])
+            seg = seg[max_lines:]
+        if cur and len(cur) + len(seg) > max_lines:
+            chunks.append(cur)
+            cur = []
+        cur += seg
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
+def chunk_code(text: str, path: str = "", max_lines: int = 60):
+    """Chunk source on top-level def/class/decorator boundaries (sentence
+    chunking shreds code). Segments are packed up to ``max_lines``, and every
+    chunk starts with a ``# file: <path>`` line so the path's tokens are
+    indexed — 'where is the router?' should match core/router.py by name.
+
+    Returns a list of ``(index, chunk_text)`` pairs.
+    """
+    lines = text.splitlines()
+    bounds = [i for i, ln in enumerate(lines) if _TOPLEVEL.match(ln)]
+    if not bounds or bounds[0] != 0:
+        bounds = [0] + bounds
+    segments = [lines[a:b] for a, b in zip(bounds, bounds[1:] + [len(lines)])]
+
+    header = f"# file: {path}" if path else None
+    out = []
+    for i, ch in enumerate(_pack(segments, max_lines)):
+        body = "\n".join(([header] if header else []) + ch)
+        out.append((i, body))
+    return out
+
+
+def chunk_text(text: str, max_words: int = 350):
+    """Chunk prose/docs into sentence-packed windows of at most ``max_words``
+    words. Returns a list of ``(index, chunk_text)`` pairs."""
+    sents = [s.strip() for s in _SENT.split(text) if s.strip()]
+    chunks, cur, cur_words = [], [], 0
+    for s in sents:
+        w = len(s.split())
+        if cur and cur_words + w > max_words:
+            chunks.append(" ".join(cur))
+            cur, cur_words = [], 0
+        cur.append(s)
+        cur_words += w
+    if cur:
+        chunks.append(" ".join(cur))
+    return list(enumerate(chunks))

--- a/tina4_python/dev_admin/__init__.py
+++ b/tina4_python/dev_admin/__init__.py
@@ -2000,6 +2000,19 @@ async def _api_reload(request, response):
     except Exception as e:
         Log.error(f"Re-discover on reload failed: {e}")
 
+    # Keep the code Context index LIVE on the same WebSocket-reload trigger:
+    # reindex just the changed file (UPSERT) so the dev-MCP code_search reflects
+    # the edit immediately. Only touches an already-built index (existing_context
+    # never creates one); guarded so a context failure never breaks the reload.
+    try:
+        if _reload_file[0]:
+            from tina4_python.context import existing_context
+            _ctx = existing_context()
+            if _ctx is not None:
+                _ctx.reindex_file(_reload_file[0])
+    except Exception as e:
+        Log.error(f"Context reindex on reload failed: {e}")
+
     # WebSocket-primary reload: push an instant message to every browser
     # connected on /__dev_reload. The toolbar client (and the dev-admin
     # dashboard) act on this immediately — the mtime poll above is only a

--- a/tina4_python/mcp/tools.py
+++ b/tina4_python/mcp/tools.py
@@ -978,30 +978,27 @@ def register_dev_tools(server):
     # "where/how is X done in THIS codebase?" and api_* for "what's the
     # signature of X?". Backed by a zero-dependency SQLite FTS5 index at
     # .tina4/context.db, kept in a closure so repeat calls reuse it.
-    _code_ctx: dict = {}
-
-    def _get_code_context():
-        from tina4_python.context import Context
-        ctx = _code_ctx.get("ctx")
-        if ctx is None:
-            ctx = Context(str(project_root / ".tina4" / "context.db"))
-            _code_ctx["ctx"] = ctx
-        return ctx
+    # Held as a PROCESS-WIDE shared Context (context.default_context) so the dev
+    # WebSocket reload hook can keep the SAME index fresh on every file save.
+    def _code_root():
+        return project_root / "src" if (project_root / "src").is_dir() else project_root
 
     def code_search(query: str, k: int = 5, rebuild: bool = False) -> list:
         """Fuzzy/semantic search over THIS project's own source + docs
         (SQLite FTS5, zero-dep). Ranks definitions above tests that merely
         mention a symbol. Use for 'where is X done here?'; use api_* for exact
         signatures. First call (or rebuild=True) indexes src/ (falls back to
-        the project root). Returns [{path, score, snippet}]."""
-        ctx = _get_code_context()
+        the project root); thereafter the dev-reload hook keeps it live on save.
+        Returns [{path, score, snippet}]."""
+        from tina4_python.context import default_context
+        ctx = default_context(root=_code_root(),
+                              db=str(project_root / ".tina4" / "context.db"))
         if not ctx.available:
             return {"error": "SQLite FTS5 is not available in this Python build; "
                              "code_search is disabled."}
-        if rebuild or ctx.is_empty():
+        if rebuild:
             ctx.reset()
-            root = project_root / "src" if (project_root / "src").is_dir() else project_root
-            ctx.index_root(root)
+            ctx.index_root(_code_root())
         return ctx.search(query, k=k)
 
     # ── Register all tools ──────────────────────────────────────

--- a/tina4_python/mcp/tools.py
+++ b/tina4_python/mcp/tools.py
@@ -971,6 +971,39 @@ def register_dev_tools(server):
         spec = Docs(project_root=str(project_root)).method_spec(class_, name)
         return spec if spec is not None else {"error": f"method not found: {class_}.{name}"}
 
+    # ── Code/doc grounding (tina4_python.context) ───────────────
+    # Sibling of api_* but the DUAL of it: api_* is exact structural
+    # reflection (class/method signatures); code_search is fuzzy/semantic
+    # FTS over the project's own SOURCE + docs. Use code_search for
+    # "where/how is X done in THIS codebase?" and api_* for "what's the
+    # signature of X?". Backed by a zero-dependency SQLite FTS5 index at
+    # .tina4/context.db, kept in a closure so repeat calls reuse it.
+    _code_ctx: dict = {}
+
+    def _get_code_context():
+        from tina4_python.context import Context
+        ctx = _code_ctx.get("ctx")
+        if ctx is None:
+            ctx = Context(str(project_root / ".tina4" / "context.db"))
+            _code_ctx["ctx"] = ctx
+        return ctx
+
+    def code_search(query: str, k: int = 5, rebuild: bool = False) -> list:
+        """Fuzzy/semantic search over THIS project's own source + docs
+        (SQLite FTS5, zero-dep). Ranks definitions above tests that merely
+        mention a symbol. Use for 'where is X done here?'; use api_* for exact
+        signatures. First call (or rebuild=True) indexes src/ (falls back to
+        the project root). Returns [{path, score, snippet}]."""
+        ctx = _get_code_context()
+        if not ctx.available:
+            return {"error": "SQLite FTS5 is not available in this Python build; "
+                             "code_search is disabled."}
+        if rebuild or ctx.is_empty():
+            ctx.reset()
+            root = project_root / "src" if (project_root / "src").is_dir() else project_root
+            ctx.index_root(root)
+        return ctx.search(query, k=k)
+
     # ── Register all tools ──────────────────────────────────────
 
     tools = [
@@ -1029,6 +1062,12 @@ def register_dev_tools(server):
         ("api_search", api_search, "Live API search — finds framework + user classes/methods by name/summary. Use BEFORE guessing a method exists."),
         ("api_class", api_class, "Live class reflection — returns full method list + signatures for an FQN."),
         ("api_method", api_method, "Live method reflection — returns signature, params, return type, file, line."),
+
+        # ── Code/doc grounding (semantic FTS over this repo's source) ──
+        # code_search is the fuzzy DUAL of the structural api_* tools:
+        # api_* = exact signature lookup; code_search = "where/how is X
+        # done in THIS codebase?" over source + docs (zero-dep FTS5).
+        ("code_search", code_search, "Fuzzy/semantic search over THIS project's source + docs (FTS5). Use for 'where/how is X done here?'; api_* for exact signatures."),
     ]
 
     for name, handler, description in tools:


### PR DESCRIPTION
Brings neemee's retrieval into Tina4 as a **native, zero-dependency** `Context` subsystem — an app can ground its own AI assistant on its own source, offline. Thin port of the proven neemee slice (SqliteFTS + chunkers + the source-over-tests / definition-first reorderings), reimplemented idiomatically. **No new dependency** — stdlib `sqlite3` FTS5 + `bm25()`.

## What's in it
- `tina4_python/context/__init__.py` — `Context`: `index_path` (UPSERT: delete-by-path + re-chunk + insert), `index_root` (walk, skips vendor/build/runtime dirs), `search` (bm25 + source-over-tests + definition-first) → `[{path, score, snippet}]`. FTS5-absent → degrades to safe no-ops.
- `tina4_python/context/chunker.py` — `fold`/`terms`/`light_stem` + `chunk_code` (def/class boundaries) + `chunk_text` (sentence boundary, no code-shredding).
- `tina4_python/mcp/tools.py` — `code_search` dev-MCP tool, sibling of `api_*` (structural) as the fuzzy/semantic dual.
- On-disk index at `.tina4/context.db` (gitignored).

## Independently verified (not the worker's green)
- Re-ran `tests/test_context.py` → **9 passed**; full sweep at this rebased HEAD (context + MCP + security + transport + dev_admin) → **150 passed**.
- Read the diff: tests are **real, no mocks** (real temp SQLite + real temp trees; MCP tested via a real server round-trip). `Context` core is a faithful port.
- Real-world smoke: indexed `tina4_python/` and queries return the right files (auth→`auth/__init__.py`, ORM→`orm/model.py`, queue→`kafka_backend.py`).
- Rebased cleanly onto current `origin/v3` (the worker built on a base 14 commits stale).

## Honest scope / follow-ups (not blockers)
- **Reindex-on-change is not auto-wired** — `index_path()` UPSERT exists (proven sub-100ms, non-duplicating) but the dev hot-reload is mtime-poll with no per-file hook, so auto-trigger-on-save is a follow-up.
- `search()`'s `score` is raw bm25, so it's **non-monotonic when the definition-first reorder fires** — trust the list order, not the score. Minor.
- Not done (out of MVP scope): skills doc + grounding-ladder entry, optional dense rerank, PHP/Ruby/Node parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)