### PR TITLE
3.13.64: scaffolding-first generators + secure-by-default route fix

### DIFF
--- a/.claude/skills/tina4-developer-python/SKILL.md
+++ b/.claude/skills/tina4-developer-python/SKILL.md
@@ -35,7 +35,7 @@ to **scope, delegate, and report** — never to build inline.
 | 2. Plan | Write the checklist `[ ]`, Bugs section, Commit log | the plan file, approved |
 | 3. Delegate | Spawn a worker per task; the main session stays free | worker(s) running off the plan |
 | 4. Test-first | The worker writes REAL tests before any code | failing tests that pin the behaviour |
-| 5. Build | Ground with `tina4_context` → climb the reuse ladder → minimum code | tests now green |
+| 5. Scaffold + Build | **Scaffold** with `tina4 generate` → fill the `AI-FILL` placeholder → ground the custom ~20% with `tina4_context` | tests now green |
 | 6. Verify | Run it for real; tick the item; log the commit | `[x]` + commit hash in the plan |
 | 7. Report | Relay worker completions to the developer as a ✅/❌ table | the status dashboard |
 
@@ -100,9 +100,18 @@ code exists**. No mocks, stubs, fakes, or "it returned 200" smoke tests — a gr
 nothing (see **No Code Without Tests** and **Testing** below). The passing real test is the
 definition of done for a checklist item.
 
-### 5. Build the minimum, grounded
-Only once the tests exist: ground with `tina4_context`, climb the reuse ladder (most features are
-already in the box), and write the minimum code that makes the tests pass. Nothing speculative.
+### 5. Scaffold the boilerplate, then fill only the custom logic
+Only once the tests exist: **scaffold with `tina4 generate <feature>`** (model, route, crud, service,
+queue, validator, seeder, websocket, listener, form, view, auth) — the boilerplate is generated
+deterministically, correct and **secure-by-default** (write routes are token-gated; pass `--public`
+to open them) — then **fill ONLY the `# ─── AI-FILL ───` placeholder** it leaves. An unfilled one
+`raise`s `NotImplementedError`, so a stub can never ship silently. Each placeholder is a tight
+fill-spec — `Intent / Given / Use / Return / Ground` — that names the **real** API to call and the
+`tina4_context(...)` query to ground the fill, so an AI (or you) completes it correctly instead of
+guessing; working CRUD code carries a lighter `# ─── EXTEND ───` marker at its extension point
+instead. That is the token-efficient split the skills evaluation validated: the ~80% boilerplate is
+*generated* (no stochastic model in that path), and the ~20% custom logic is where you write —
+grounded with `tina4_context`. Climb the reuse ladder for anything the scaffolder can't express.
 
 ### 6. Verify for real, then log the commit
 An item is `[x]` only when its real tests pass against a real run. When it lands, record the
@@ -129,15 +138,16 @@ a feature.
 
 ## Before you write code — the reuse ladder
 
-Climb in order; write new code only at the last rung. Tina4 ships **54 built-in features, zero dependencies** — most "new code" is already in the box.
+Climb in order; write new code only at the last rung. Tina4 ships **54 built-in features, zero dependencies** — most "new code" is already in the box, and most of the rest can be **scaffolded**.
 
 1. **Does it need to exist?** Re-read the request and trace the actual code flow. The best change is often none.
 2. **Does Tina4 already do it?** Check built-ins first: CRUD → `auto_crud = True` (AutoCrud); DB → the ORM (`Model.all()/.where()`); Auth/JWT → `Auth`; validation → `Validator`; seed/fake data → `FakeData`/`seed_orm`; email → `Messenger`; queue → `Queue`; templates → Frond; sessions, i18n, WebSockets, GraphQL, realtime — all built in.
-3. **Does the Python stdlib do it?** (`datetime`, `json`, `hashlib`, `uuid`…) Use it before reaching further.
-4. **Is it already in THIS app?** Reuse the existing model/route/service — don't duplicate.
-5. **Adding a dependency? Stop.** Tina4 is zero-dependency — find the built-in.
-6. **Can it be one field-object / one route / one line?** Prefer the smallest declarative form (a `ForeignKeyField`, a decorator).
-7. **Only now**, write the minimum that works — no wrappers, no speculative options.
+3. **Can `tina4 generate` scaffold it?** Prefer the generator over hand-writing boilerplate: `tina4 generate <feature>` (model, route, crud, migration, service, queue, validator, seeder, websocket, listener, form, view, auth) emits correct, **secure-by-default** wiring (write routes token-gated; `--public` to open) and leaves an `# ─── AI-FILL ───` fill-spec placeholder — you fill only the custom logic. Keep the stochastic model out of the boilerplate path.
+4. **Does the Python stdlib do it?** (`datetime`, `json`, `hashlib`, `uuid`…) Use it before reaching further.
+5. **Is it already in THIS app?** Reuse the existing model/route/service — don't duplicate.
+6. **Adding a dependency? Stop.** Tina4 is zero-dependency — find the built-in.
+7. **Can it be one field-object / one route / one line?** Prefer the smallest declarative form (a `ForeignKeyField`, a decorator).
+8. **Only now**, write the minimum that works — no wrappers, no speculative options.
 
 ## Retrieve the Current API With `tina4_context` — Then Write the Code Yourself
 

--- a/llms.txt
+++ b/llms.txt
@@ -192,3 +192,10 @@ tests/          # pytest test files
 9. Server entry point: `from tina4_python.core import run; run()`
 10. Default port: 7145
 11. ORM defaults table name to lowercase class name (`Contact` → `contact`). Set `ORM_PLURAL_TABLE_NAMES=true` in `.env` to append "s"
+
+## Scaffolding (`tina4py generate`)
+Scaffold boilerplate instead of hand-writing it: `tina4py generate <feature>` for model, route, crud,
+migration, service, queue, validator, seeder, websocket, listener, form, view, auth. Generated write
+routes are secure by default (token-gated; pass `--public` to open them); reads are public. Logic
+stubs carry an AI-FILL fill-spec placeholder (Intent/Given/Use/Return/Ground + a loud not-implemented
+throw) — fill only that; working CRUD carries a lighter EXTEND marker.

--- a/plan/scaffolding-first.md
+++ b/plan/scaffolding-first.md
@@ -1,0 +1,90 @@
+# Plan: Scaffolding-first — a generator for every feature, with `# your code here` placeholders
+
+## Why
+The 3.13.60 skills eval (`evaluate-skills/run-3.13.60/TAKEAWAYS.md` §6) proved the token-efficient,
+correct pattern: **deterministic scaffolding for the ~80% boilerplate + a grounded model for the ~20%
+custom logic — no stochastic model in the boilerplate path.** Today that isn't fully deliverable:
+1. **Skills don't lead with scaffolding.** The reuse ladder says "does Tina4 already do it" but never
+   "scaffold it first with `tina4 generate`". Scaffolding is buried, not the default move.
+2. **Generators don't leave placeholders.** `generate route` emits *full* CRUD logic (or nothing for a
+   custom route) — there's no clear `# your code here` marker telling the AI/dev exactly where the
+   custom 20% goes. So the model rewrites the whole thing instead of filling a gap.
+3. **Coverage is uneven.** Generators exist for model/route/crud/migration/middleware/test/form/view/
+   auth — but NOT for service (scheduler), queue (producer/consumer), validator, seeder, websocket,
+   event listener, mcp-tool, cache, i18n, graphql, email. "Scaffolding for every feature" is unmet.
+4. **The scaffolder repeats the secure-by-default footgun** — `generate route --model` puts `@noauth()`
+   on the `create` (POST) handler (cli/__init__.py:857): public writes, same bug we just fixed in
+   AutoCrud. The scaffolder must be secure-by-default too.
+
+## The three pillars
+
+### A. The AI-FILL placeholder convention (the core idea)  — SHIPPED (python `c0b2085`)
+Every generated file scaffolds the *wiring* (imports, decorator, signature, registration) and marks
+the *custom logic* with ONE unmistakable, AI-fillable block — a tight fill-spec, not a bare `# TODO`:
+```python
+    # ─── AI-FILL: create_product ─────────────────────────────────────
+    # Intent:  validate the body and persist a new product
+    # Given:   request.body -> dict of fields
+    # Use:     Product.create(request.body)   (a REAL, grounded symbol)
+    # Return:  response(item.to_dict(), 201)
+    # Ground:  tina4_context("create ORM record and return 201", "python")
+    raise NotImplementedError("create_product: persist and return the new record")
+    # ─────────────────────────────────────────────────────────────────
+```
+Rationale: `raise NotImplementedError` makes an unfilled scaffold **fail loudly** (never silently ship
+a stub); the greppable `AI-FILL` banner lets a human or agent jump to every gap; and the
+`Intent/Given/Use/Return/Ground` spec (≤6 lines, `Use:` naming only symbols verified in live source)
+means an AI completes it *correctly and idiomatically* instead of guessing — the scaffold itself is an
+anti-drift anchor. CRUD-shaped generators (crud/form/view + `route --model`) emit working code (the
+boilerplate IS the feature) with a lighter `# ─── EXTEND ───` marker at the extension point; logic-shaped
+generators (custom route, service, queue consumer, validator, seeder, websocket, listener) emit wiring +
+the AI-FILL placeholder. Implemented via the `_ai_fill()` / `_extend()` helpers in `cli/__init__.py`.
+
+### B. A generator for every feature (fill the gaps), each secure-by-default
+| Feature | Command | Scaffolds (wiring) | Placeholder holds |
+|---|---|---|---|
+| custom route | `generate route <name>` (no --model) | decorator + `@secured` on writes + signature | the handler body |
+| service/scheduler | `generate service <Name> --every 5m` | `ServiceRunner.register(...)` + fn | the task body |
+| queue | `generate queue <topic>` | producer `.push()` + consumer `.consume()` + `job.complete()` | the consume body |
+| validator | `generate validator <Name>` | `Validator` rules skeleton | the rule set |
+| seeder | `generate seeder <Model>` | `FakeData` loop + `seed_orm` | the field mapping |
+| websocket | `generate websocket <path>` | `on_message`/`broadcast` handler | the message body |
+| listener | `generate listener <event>` | `@on("<event>")` + signature | the reaction body |
+| mcp-tool | `generate mcp-tool <name>` | `McpServer`/`mcp_tool` registration | the tool body |
+Reuse ladder still applies: e.g. `crud` remains AutoCrud-first; a generated custom route is for the
+cases AutoCrud can't express (the §6 custom 20%: ordering, auth nuance, business rules).
+
+### C. Skills lead with scaffolding
+- **Working Method**: insert a **Scaffold** step before Build — "scaffold the boilerplate with
+  `tina4 generate <feature>`, then fill only the `# your code here` placeholder." Update the phase table.
+- **Reuse ladder**: new rung near the top — *"Can a generator scaffold it? `tina4 generate <feature>`
+  → then fill the placeholder."* — above "write the minimum".
+- Document the full `generate` surface + the placeholder convention + the "boilerplate deterministic,
+  custom grounded" split from the eval. All 4 dev skills + maintainer.
+
+## Fix carried along
+Remove `@noauth()` from the write handler(s) the route generator emits (secure-by-default), mirroring
+the 3.13.62/63 AutoCrud fix. A `--public` flag is the explicit opt-out, same as AutoCrud's `public=True`.
+
+## Scope / sequencing
+- **Reference: python first**, then parity to php/ruby/node (each framework's generator + templates).
+- **MVP order (highest leverage first):** (1) placeholder convention + fix the route-generator footgun;
+  (2) skills scaffolding emphasis (the adoption lever — cheap, immediate); (3) the missing generators
+  (service, queue, validator, seeder, websocket, listener), one at a time with a REAL test that the
+  generated file imports/registers and the placeholder raises NotImplementedError; (4) parity.
+
+## Tests (real, no mocks)
+Per generator: run it into a temp project, assert the file exists at the convention path, **imports
+cleanly**, registers its route/service/consumer, and the placeholder raises `NotImplementedError`
+until filled. Secure-by-default: a generated write route has no `_noauth` unless `--public`.
+
+## Status
+- [x] **Python MVP shipped** — `feat/scaffolding-first` `c0b2085`: secure-by-default `_gen_route`
+  (`@noauth` gone from reads+create; `--public` opt-in on writes only; auth generator left public),
+  AI-FILL convention (`_ai_fill`/`_extend`), 6 new generators (service/queue/validator/seeder/
+  websocket/listener). Tests: 58 scaffolding + full suite **3354 passed / 0 failed** (independently
+  re-run). tina4_context MCP was unreachable → grounded on skill + live source (every symbol file:line'd).
+- [x] Skills scaffolding emphasis (this file's SKILL.md edits).
+- [ ] **Parity** — php / ruby / node workers in flight (`feat/scaffolding-first` off `v3` each).
+- [ ] Verify parity suites · update all skills + docs · release + validate · reindex corpus.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tina4-python"
-version = "3.13.63"
+version = "3.13.64"
 description = "Tina4 Python v3 — Zero-dependency, lightweight web framework"
 authors = [
     {name = "Andre van Zuydam", email = "andrevanzuydam@gmail.com"}

--- a/tests/test_cli_generate.py
+++ b/tests/test_cli_generate.py
@@ -1,23 +1,77 @@
 """Tests for CLI scaffolding generators."""
+import ast
+import asyncio
+import importlib.util
 import os
 import shutil
+import subprocess
+import sys
 import pytest
 from pathlib import Path
 from tina4_python.cli import (
     _parse_fields, _parse_flags, _to_snake, _to_table,
     _gen_model, _gen_route, _gen_migration, _gen_middleware,
     _gen_test, _gen_form, _gen_view, _gen_auth, _gen_crud,
+    _gen_service, _gen_queue, _gen_validator, _gen_seeder,
+    _gen_websocket, _gen_listener, _ai_fill, _extend, _parse_every,
     FIELD_TYPE_MAP,
 )
 
 
 @pytest.fixture
 def tmp_project(tmp_path):
-    """Create a temp project directory and cd into it."""
+    """Create a temp project directory, cd into it, and put it on sys.path so a
+    generated file's `from src.orm.X import X` resolves to THIS project."""
     old_cwd = os.getcwd()
     os.chdir(tmp_path)
+    sys.path.insert(0, str(tmp_path))
     yield tmp_path
     os.chdir(old_cwd)
+    try:
+        sys.path.remove(str(tmp_path))
+    except ValueError:
+        pass
+    # Drop any `src.*` modules this test imported so the name can't resolve to a
+    # previous tmp project on the next test.
+    for mod in [m for m in list(sys.modules) if m == "src" or m.startswith("src.")]:
+        del sys.modules[mod]
+
+
+def _load_generated(path: Path, modname: str):
+    """Import a generated file for real (no mocks) and return the module.
+
+    Executes the module top-to-bottom, so decorator-based wiring (@websocket,
+    @on) actually registers on the real Router / event bus, and a bad import
+    raises ImportError here — proving the scaffold's imports resolve.
+    """
+    assert path.exists(), f"expected generated file at {path}"
+    # Fresh-resolve any `src.*` imports (avoid a stale tmp binding).
+    for mod in [m for m in list(sys.modules) if m == "src" or m.startswith("src.")]:
+        del sys.modules[mod]
+    spec = importlib.util.spec_from_file_location(modname, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def clean_registry():
+    """Clear the global Router / event bus / DB binding around a behavioural
+    test so registrations and bindings never leak between tests."""
+    from tina4_python.core.router import Router
+    # core.events re-exports an `events()` fn that shadows the submodule attr, so
+    # `import ... as ev` yields the function — import_module returns the module.
+    ev = importlib.import_module("tina4_python.core.events")
+    import tina4_python.orm.model as orm_model
+
+    Router.clear()
+    ev.clear()
+    _prev_db = getattr(orm_model, "_database", None)
+    yield
+    Router.clear()
+    ev.clear()
+    orm_model._database = _prev_db
 
 
 # ── Helper tests ──────────────────────────────────────────────────────
@@ -141,10 +195,14 @@ class TestGenerateRoute:
         assert "Product.create" in content
 
     def test_route_without_model(self, tmp_project):
+        # No --model → a custom route: every handler body is an AI-FILL stub
+        # (raise NotImplementedError), not working code and not a public write.
         _gen_route("items", {})
         content = (tmp_project / "src" / "routes" / "items.py").read_text()
-        assert "from src.orm" not in content
-        assert '{"data": []}' in content
+        assert "from src.orm.Item import" not in content  # no real model import
+        assert "AI-FILL" in content
+        assert "raise NotImplementedError" in content
+        assert "@noauth" not in content  # secure by default
 
 
 # ── Migration generator ──────────────────────────────────────────────
@@ -306,3 +364,342 @@ class TestGenerateCrud:
         _gen_crud("Product", {"fields": "name:string"})
         content = (tmp_project / "src" / "routes" / "products.py").read_text()
         assert "from src.orm.Product import Product" in content
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Scaffolding-first acceptance matrix — real temp project, real test
+# client, NO mocks. Compile + import + boot behaviour, not string-grep.
+# ══════════════════════════════════════════════════════════════════════
+
+def _compiles(path: Path):
+    """B2 — the generated source COMPILES (stricter than ast.parse)."""
+    src = path.read_text()
+    compile(src, str(path), "exec")   # raises SyntaxError if not
+
+
+# ── Placeholder / helper unit tests ───────────────────────────────────
+
+class TestPlaceholderHelpers:
+    def test_ai_fill_is_a_grounded_fill_spec(self):
+        block = _ai_fill(
+            "create_widget", "persist a widget", "Widget.create(request.body)",
+            "create_widget: persist and return",
+            given="request.body -> dict", ret="response(item.to_dict(), 201)",
+            ground='tina4_context("create ORM record", "python")',
+        )
+        assert "AI-FILL: create_widget" in block
+        assert "# Intent:" in block and "# Use:" in block and "# Ground:" in block
+        assert 'raise NotImplementedError("create_widget: persist and return")' in block
+
+    def test_extend_marks_without_notimplemented(self):
+        block = _extend("validate before persist", "e.g. reject invalid input")
+        assert "EXTEND: validate before persist" in block
+        assert "NotImplementedError" not in block
+
+    def test_parse_every_durations(self):
+        assert _parse_every("5m") == 300
+        assert _parse_every("30s") == 30
+        assert _parse_every("2h") == 7200
+        assert _parse_every("1d") == 86400
+        assert _parse_every("45") == 45
+        assert _parse_every("") == 60          # default
+        assert _parse_every("garbage") == 60   # unparseable → default
+
+
+# ── Route: secure-by-default BEHAVIOUR (R1–R4) ────────────────────────
+
+def _boot_model_route(tmp_project, model, route, *, public=False, fields="name:string"):
+    """Generate model + route, bind a REAL sqlite DB, create the table, import
+    the route (registers the 5 handlers). Returns the imported route module."""
+    from tina4_python.database import Database
+    from tina4_python.orm.model import bind_database
+
+    _gen_model(model, {"fields": fields, "no-migration": True})
+    flags = {"model": model}
+    if public:
+        flags["public"] = True
+    _gen_route(route, flags)
+
+    bind_database(Database(f"sqlite:///{tmp_project}/app.db"))
+    mod = _load_generated(tmp_project / "src" / "routes" / f"{route}.py", f"genroute_{route}")
+    getattr(mod, model).create_table()
+    return mod
+
+
+class TestRouteSecureByDefaultBehaviour:
+    def test_model_route_boot_gate(self, tmp_project, clean_registry):
+        from tina4_python.core.router import Router
+        from tina4_python.test_client import TestClient
+        from tina4_python.auth import get_token
+        os.environ["TINA4_SECRET"] = "scaffold-test-secret"
+        os.environ.pop("TINA4_API_KEY", None)
+
+        _boot_model_route(tmp_project, "Sprocket", "sprockets")
+
+        # R1 — all five routes registered.
+        paths = {(r["method"], r["path"]) for r in Router.get_routes()}
+        assert ("GET", "/api/sprockets") in paths
+        assert ("GET", "/api/sprockets/{id:int}") in paths
+        assert ("POST", "/api/sprockets") in paths
+        assert ("PUT", "/api/sprockets/{id:int}") in paths
+        assert ("DELETE", "/api/sprockets/{id:int}") in paths
+
+        client = TestClient()
+        # R2 — secure by default, proven by behaviour.
+        assert client.get("/api/sprockets").status == 200                       # read public
+        assert client.get("/api/sprockets/1").status in (200, 404)              # read public
+        assert client.post("/api/sprockets", json={"name": "a"}).status == 401  # write gated
+        token = get_token({"user_id": 1})
+        created = client.post("/api/sprockets", json={"name": "a"},
+                              headers={"Authorization": f"Bearer {token}"})
+        assert created.status == 201                                            # token → 201
+
+    def test_model_route_source_has_no_noauth_by_default(self, tmp_project):
+        # R4 — no @noauth, no noauth import, secure by default.
+        _gen_model("Cog", {"fields": "name:string", "no-migration": True})
+        _gen_route("cogs", {"model": "Cog"})
+        src = (tmp_project / "src" / "routes" / "cogs.py").read_text()
+        assert "@noauth" not in src
+        assert "noauth" not in src.splitlines()[0]  # not imported
+
+
+class TestRoutePublicOptOut:
+    def test_public_route_boot_gate(self, tmp_project, clean_registry):
+        from tina4_python.test_client import TestClient
+        os.environ["TINA4_SECRET"] = "scaffold-test-secret"
+        os.environ.pop("TINA4_API_KEY", None)
+
+        _boot_model_route(tmp_project, "Widget", "widgets", public=True)
+        client = TestClient()
+        # R3 — --public opened the writes: anonymous POST creates.
+        assert client.post("/api/widgets", json={"name": "a"}).status == 201
+        # DELETE is open too (gate passed → handler runs → 404 for the missing row).
+        assert client.delete("/api/widgets/999").status in (204, 404)
+
+    def test_public_route_source_has_noauth_on_writes_only(self, tmp_project):
+        # R4 (--public) — @noauth on the 3 writes, noauth imported, never on GETs.
+        _gen_model("Gadget", {"fields": "name:string", "no-migration": True})
+        _gen_route("gadgets", {"model": "Gadget", "public": True})
+        src = (tmp_project / "src" / "routes" / "gadgets.py").read_text()
+        assert src.count("@noauth()") == 3            # create + update + delete
+        assert "get, post, put, delete, noauth" in src
+        # @noauth sits directly above each WRITE handler, and neither READ.
+        assert '@noauth()\n@description("Create a new gadget")' in src
+        assert '@noauth()\n@description("Update a gadget")' in src
+        assert '@noauth()\n@description("Delete a gadget")' in src
+        assert '@noauth()\n@description("List all gadgets")' not in src
+        assert '@noauth()\n@description("Get a gadget by ID")' not in src
+
+
+class TestRouteNoModelStub:
+    def test_no_model_route_is_a_live_stub(self, tmp_project, clean_registry):
+        from tina4_python.core.router import Router
+        from tina4_python.test_client import TestClient
+        os.environ["TINA4_SECRET"] = "scaffold-test-secret"
+        os.environ.pop("TINA4_API_KEY", None)
+
+        _gen_route("notes", {})
+        path = tmp_project / "src" / "routes" / "notes.py"
+        _compiles(path)                                        # B2
+        mod = _load_generated(path, "genroute_notes")          # B3 imports clean
+        # R1 — five routes registered.
+        assert len([r for r in Router.get_routes() if "/api/notes" in r["path"]]) == 5
+        # S2 — AI-FILL banner + Ground line present.
+        src = path.read_text()
+        assert "AI-FILL" in src and "# Ground:" in src
+        # Secure gate holds even though the handler is a stub (gate runs first).
+        assert TestClient().post("/api/notes", json={}).status == 401
+        # S1 — calling a handler raises NotImplementedError (placeholder is live).
+        from tina4_python.core.request import Request
+        from tina4_python.core.response import Response
+        req = Request.from_scope({"type": "http", "method": "GET", "path": "/api/notes",
+                                  "query_string": b"", "headers": [], "client": ("127.0.0.1", 0)}, b"")
+        with pytest.raises(NotImplementedError):
+            asyncio.run(mod.list_notes(req, Response()))
+
+
+# ── CRUD: generated test file itself PASSES (R5) ──────────────────────
+
+class TestCrudGeneratedTestPasses:
+    def test_generated_crud_test_runs_green(self, tmp_project):
+        _gen_crud("Trinket", {"fields": "name:string,qty:int"})
+        # R5 — the emitted test file executes green in a real pytest subprocess.
+        test_file = tmp_project / "tests" / "test_trinkets.py"
+        assert test_file.exists()
+        env = {**os.environ, "PYTHONPATH": str(tmp_project)}
+        env.pop("TINA4_API_KEY", None)
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(test_file), "-q"],
+            cwd=str(tmp_project), env=env, capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stdout + "\n" + result.stderr
+
+    def test_crud_default_routes_secure(self, tmp_project):
+        _gen_crud("Doohickey", {"fields": "name:string"})
+        src = (tmp_project / "src" / "routes" / "doohickeys.py").read_text()
+        assert "@noauth" not in src
+
+    def test_crud_public_routes_open_writes(self, tmp_project):
+        _gen_crud("Contraption", {"fields": "name:string", "public": True})
+        src = (tmp_project / "src" / "routes" / "contraptions.py").read_text()
+        assert src.count("@noauth()") == 3
+
+
+# ── The six new logic-shaped generators (B1–B4 + S1–S3) ───────────────
+
+class TestServiceGenerator:
+    def test_interval_service(self, tmp_project, capsys):
+        _gen_service("Reaper", {"every": "5m"})
+        path = tmp_project / "src" / "services" / "reaper.py"
+        assert path.exists()                       # B1
+        _compiles(path)                            # B2
+        mod = _load_generated(path, "gen_reaper")  # B3
+        # B4 — second run refuses to overwrite.
+        _gen_service("Reaper", {"every": "5m"})
+        assert "already exists" in capsys.readouterr().out
+        # S2 — AI-FILL + Ground.
+        src = path.read_text()
+        assert "AI-FILL" in src and "# Ground:" in src
+        # S1 — the task body raises until filled.
+        with pytest.raises(NotImplementedError):
+            mod.reaper_task(None)
+        # S3 — the service is registrable / discoverable on a REAL ServiceRunner.
+        from tina4_python.service import ServiceRunner
+        assert mod.service["name"] == "reaper" and mod.service["interval"] == 300
+        runner = ServiceRunner()
+        mod.register(runner)
+        assert any(s["name"] == "reaper" for s in runner.list())
+        assert "reaper" in ServiceRunner().discover("src/services")
+
+    def test_cron_service(self, tmp_project):
+        _gen_service("Nightly", {"cron": "0 3 * * *"})
+        mod = _load_generated(tmp_project / "src" / "services" / "nightly.py", "gen_nightly")
+        assert mod.service["cron"] == "0 3 * * *"
+
+
+class TestQueueGenerator:
+    def test_queue_consumer_and_producer(self, tmp_project):
+        _gen_queue("order-emails", {})
+        path = tmp_project / "src" / "services" / "order_emails_consumer.py"
+        assert path.exists()                              # B1
+        _compiles(path)                                   # B2
+        mod = _load_generated(path, "gen_queue_orders")   # B3
+        src = path.read_text()
+        assert "AI-FILL" in src and "# Ground:" in src    # S2
+        # S1 — the consume body raises until filled.
+        with pytest.raises(NotImplementedError):
+            mod.handle_order_emails({})
+        # S3 — consumer wired as a daemon service; producer is callable + real.
+        assert mod.service["daemon"] is True
+        assert mod.service["handler"].__name__ == "consume_order_emails"
+        job_id = mod.publish_order_emails({"to": "a@b.c"})  # real file-backend push
+        assert job_id
+        assert "order-emails-consumer" in ServiceRunnerNames(tmp_project)
+
+    def test_idempotent(self, tmp_project, capsys):
+        _gen_queue("invoices", {})
+        _gen_queue("invoices", {})
+        assert "already exists" in capsys.readouterr().out
+
+
+def ServiceRunnerNames(tmp_project):
+    from tina4_python.service import ServiceRunner
+    return ServiceRunner().discover("src/services")
+
+
+class TestValidatorGenerator:
+    def test_validator(self, tmp_project, capsys):
+        _gen_validator("CreateUser", {})
+        path = tmp_project / "src" / "validators" / "create_user.py"
+        assert path.exists()                                # B1
+        _compiles(path)                                     # B2
+        mod = _load_generated(path, "gen_validator")        # B3
+        _gen_validator("CreateUser", {})                    # B4
+        assert "already exists" in capsys.readouterr().out
+        src = path.read_text()
+        assert "AI-FILL" in src and "# Ground:" in src      # S2
+        assert "from tina4_python.validator import Validator" in src  # S3 wiring
+        with pytest.raises(NotImplementedError):            # S1
+            mod.validate_create_user({})
+
+
+class TestSeederGenerator:
+    def test_seeder(self, tmp_project, capsys):
+        from tina4_python.seeder import FakeData
+        _gen_model("Sprocket", {"fields": "name:string", "no-migration": True})
+        _gen_seeder("Sprocket", {})
+        path = tmp_project / "src" / "seeds" / "sprocket_seeder.py"
+        assert path.exists()                                # B1
+        _compiles(path)                                     # B2
+        mod = _load_generated(path, "gen_seeder")           # B3 (resolves src.orm.Sprocket)
+        _gen_seeder("Sprocket", {})                         # B4
+        assert "already exists" in capsys.readouterr().out
+        src = path.read_text()
+        assert "AI-FILL" in src and "# Ground:" in src      # S2
+        assert "seed_orm" in src and "run" in src           # S3 wiring (run() for `tina4 seed`)
+        with pytest.raises(NotImplementedError):            # S1
+            mod.field_overrides(FakeData())
+
+
+class TestWebsocketGenerator:
+    def test_websocket(self, tmp_project, capsys, clean_registry):
+        from tina4_python.core.router import Router
+        _gen_websocket("chat", {})
+        path = tmp_project / "src" / "routes" / "ws_chat.py"
+        assert path.exists()                                # B1
+        _compiles(path)                                     # B2
+        mod = _load_generated(path, "gen_ws")               # B3
+        _gen_websocket("chat", {})                          # B4
+        assert "already exists" in capsys.readouterr().out
+        src = path.read_text()
+        assert "AI-FILL" in src and "# Ground:" in src      # S2
+        # S3 — the ws handler registered on the real Router.
+        assert any(r["path"] == "/ws/chat" for r in Router.get_web_socket_routes())
+        # S1 — the message body raises until filled.
+        with pytest.raises(NotImplementedError):
+            asyncio.run(mod.chat_ws(None, "message", None))
+
+
+class TestListenerGenerator:
+    def test_listener(self, tmp_project, capsys, clean_registry):
+        events = importlib.import_module("tina4_python.core.events")
+        _gen_listener("user.created", {})
+        path = tmp_project / "src" / "listeners" / "user_created.py"
+        assert path.exists()                                # B1
+        _compiles(path)                                     # B2
+        mod = _load_generated(path, "gen_listener")         # B3
+        _gen_listener("user.created", {})                   # B4
+        assert "already exists" in capsys.readouterr().out
+        src = path.read_text()
+        assert "AI-FILL" in src and "# Ground:" in src      # S2
+        # S3 — the listener bound on the real event bus.
+        assert "user.created" in events.events()
+        assert len(events.listeners("user.created")) >= 1
+        # S1 — the reaction body raises until filled.
+        with pytest.raises(NotImplementedError):
+            mod.on_user_created({"id": 1})
+
+
+# ── Regression guard (A1) + robustness (N1) ───────────────────────────
+
+class TestAuthNotOverSwept:
+    def test_auth_routes_still_public(self, tmp_project):
+        # A1 — the CRUD secure-by-default fix must NOT strip @noauth from the
+        # genuinely-public auth routes (login/register).
+        _gen_auth()
+        src = (tmp_project / "src" / "routes" / "auth.py").read_text()
+        assert src.count("@noauth()") >= 2   # register + login are public
+
+
+class TestRobustness:
+    def test_invalid_fields_no_stacktrace(self, tmp_project):
+        # N1 — a malformed --fields value must not raise.
+        _gen_model("Junk", {"fields": ":::,,,bad"})
+        assert (tmp_project / "src" / "orm" / "Junk.py").exists()
+
+    def test_existing_file_not_clobbered(self, tmp_project, capsys):
+        _gen_validator("Once", {})
+        original = (tmp_project / "src" / "validators" / "once.py").read_text()
+        _gen_validator("Once", {})
+        assert (tmp_project / "src" / "validators" / "once.py").read_text() == original
+        assert "already exists" in capsys.readouterr().out

--- a/tina4_python/__init__.py
+++ b/tina4_python/__init__.py
@@ -8,7 +8,7 @@ Tina4 Python v3.0 — Zero-dependency, lightweight web framework.
 
 One import, everything works.
 """
-__version__ = "3.13.63"
+__version__ = "3.13.64"
 
 # ── Route decorators ──
 from tina4_python.core.router import (  # noqa: E402, F401

--- a/tina4_python/cli/__init__.py
+++ b/tina4_python/cli/__init__.py
@@ -71,7 +71,8 @@ def _parse_fields(fields_str: str) -> list[tuple[str, str]]:
 def _parse_flags(args: list[str]) -> tuple[dict, list[str]]:
     """Parse --key value and --flag from args. Returns (flags, positional)."""
     # Boolean-only flags that never take a value argument
-    boolean_flags = {"no-browser", "no-reload", "production", "managed", "all", "clear", "json"}
+    boolean_flags = {"no-browser", "no-reload", "production", "managed", "all", "clear", "json",
+                     "public", "no-migration"}
 
     flags = {}
     positional = []
@@ -92,6 +93,75 @@ def _parse_flags(args: list[str]) -> tuple[dict, list[str]]:
             positional.append(args[i])
             i += 1
     return flags, positional
+
+
+def _ai_fill(fn: str, intent: str, use: str, raise_msg: str, *,
+             given: str = "", ret: str = "", ground: str = "",
+             indent: str = "    ") -> str:
+    """Return the canonical AI-FILL placeholder block for a LOGIC-shaped stub.
+
+    A tight, grounded *fill-spec* — not a vague ``# TODO`` — so a coding agent
+    (or dev) completes it correctly and idiomatically. ``raise
+    NotImplementedError`` makes an unfilled scaffold fail LOUD, and the greppable
+    ``AI-FILL`` banner lets a human/agent jump to every gap in a file. ≤ 6
+    comment lines; ``Use:`` names only REAL Tina4 symbols (verified in source).
+
+        {indent}# ─── AI-FILL: <fn> ───────────────────────────────
+        {indent}# Intent:  <what this must do>
+        {indent}# Given:   <inputs + shape>
+        {indent}# Use:     <named REAL Tina4 API — the idiomatic path>
+        {indent}# Return:  <exact return value + status>
+        {indent}# Ground:  tina4_context("<intent>", "python") · skill tina4-developer-python
+        {indent}raise NotImplementedError("<feature>: <what>")   # remove when done
+        {indent}# ─────────────────────────────────────────────────
+    """
+    bar = "─" * 60
+    head = f"{indent}# ─── AI-FILL: {fn} "
+    head = head + "─" * max(4, 66 - len(head))
+    lines = [head, f"{indent}# Intent:  {intent}"]
+    if given:
+        lines.append(f"{indent}# Given:   {given}")
+    lines.append(f"{indent}# Use:     {use}")
+    if ret:
+        lines.append(f"{indent}# Return:  {ret}")
+    if ground:
+        lines.append(f"{indent}# Ground:  {ground}")
+    lines.append(f'{indent}raise NotImplementedError("{raise_msg}")   # remove when done')
+    lines.append(f"{indent}# {bar}")
+    return "\n".join(lines) + "\n"
+
+
+def _extend(note: str, hint: str = "", indent: str = "    ") -> str:
+    """Return the lighter EXTEND marker for CRUD-shaped WORKING code.
+
+    Marks the natural extension point in generated code that already runs — NO
+    ``NotImplementedError`` (the boilerplate IS the feature); just a greppable
+    hint at where custom validation / business rules go.
+    """
+    head = f"{indent}# ─── EXTEND: {note} "
+    head = head + "─" * max(4, 66 - len(head))
+    out = head + "\n"
+    if hint:
+        out += f"{indent}# {hint}\n"
+    return out
+
+
+def _parse_every(every: str) -> int:
+    """Parse a --every duration ('5m', '30s', '2h', '1d', or bare seconds) → seconds.
+
+    Falls back to 60s on an empty/unparseable value so a scaffold always has a
+    valid interval for ServiceRunner.register(interval=...).
+    """
+    if not every:
+        return 60
+    every = str(every).strip().lower()
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    try:
+        if every[-1] in units:
+            return max(1, int(float(every[:-1]) * units[every[-1]]))
+        return max(1, int(float(every)))
+    except (ValueError, IndexError):
+        return 60
 
 
 def _kill_process_on_port(port: int) -> bool:
@@ -227,14 +297,24 @@ Commands:
 
 Generators:
   generate model <Name> [--fields "name:string,price:float"]
-  generate route <name> [--model Name]
-  generate crud <Name> [--fields "..."]   Model + migration + routes + form + view + test
+  generate route <name> [--model Name] [--public]   Writes secure by default; --public opens them
+  generate crud <Name> [--fields "..."] [--public]   Model + migration + routes + form + view + test
   generate migration <description>
   generate middleware <Name>
   generate test <name>
   generate form <Name> [--fields "..."]   Form template with inputs matching model fields
   generate view <Name> [--fields "..."]   List + detail templates for viewing records
   generate auth                           Login/register/logout routes + User model + templates
+  generate service <Name> [--every 5m | --cron "..."]   Scheduled ServiceRunner task (src/services/)
+  generate queue <topic>                  Producer + consumer worker (src/services/)
+  generate validator <Name>               Request-body Validator (src/validators/)
+  generate seeder <Model>                 FakeData + seed_orm seeder (src/seeds/)
+  generate websocket <path>               @websocket handler (src/routes/)
+  generate listener <event>               @on(event) listener (src/listeners/)
+
+Scaffolding-first: logic-shaped generators emit wiring + an AI-FILL placeholder
+(raise NotImplementedError) where the custom logic goes; CRUD-shaped ones emit
+working code. Writes are secure by default — use --public to open them.
 
 Field types: string, int, float, bool, text, datetime, blob
 Table names: singular by default (Product → product)
@@ -704,11 +784,23 @@ def _ai(args):
 # ── Generate (rich scaffolding) ───────────────────────────────────────
 
 def _generate(args):
-    """Generate scaffolding: model, route, crud, migration, middleware, test, form, view, auth."""
+    """Generate scaffolding.
+
+    CRUD-shaped generators (crud/form/view/migration/model/test/auth) emit
+    working code — the boilerplate IS the feature. Logic-shaped generators
+    (route/service/queue/validator/seeder/websocket/listener) scaffold the
+    WIRING (real imports + registration + signature + error skeleton) and drop a
+    single ``# your code here`` placeholder (``raise NotImplementedError``) where
+    the custom logic goes, so an unfilled scaffold fails loud.
+    """
+    _all = ("model, route, crud, migration, middleware, test, form, view, auth, "
+            "service, queue, validator, seeder, websocket, listener")
     if not args:
         print("Usage: tina4python generate <what> <name> [options]")
-        print("  Generators: model, route, crud, migration, middleware, test, form, view, auth")
+        print(f"  Generators: {_all}")
         print('  Options:    --fields "name:string,price:float"  --model ModelName')
+        print('              --public                 open a route\'s writes (default: secure)')
+        print('              --every 5m | --cron "..."  service schedule')
         sys.exit(1)
 
     what = args[0].lower()
@@ -732,6 +824,12 @@ def _generate(args):
         "form": _gen_form,
         "view": _gen_view,
         "auth": _gen_auth,
+        "service": _gen_service,
+        "queue": _gen_queue,
+        "validator": _gen_validator,
+        "seeder": _gen_seeder,
+        "websocket": _gen_websocket,
+        "listener": _gen_listener,
     }
 
     gen = generators.get(what)
@@ -739,7 +837,7 @@ def _generate(args):
         gen(name, flags)
     else:
         print(f"Unknown generator: {what}")
-        print("  Available: model, route, crud, migration, middleware, test, form, view, auth")
+        print(f"  Available: {_all}")
         sys.exit(1)
 
 
@@ -797,14 +895,22 @@ def _gen_model(name: str, flags: dict):
 
 
 def _gen_route(name: str, flags: dict):
-    """Generate CRUD route file.
+    """Generate CRUD route file — SECURE BY DEFAULT.
 
     tina4python generate route products
     tina4python generate route products --model Product
+    tina4python generate route products --model Product --public   # open writes
+
+    Writes (POST/PUT/DELETE) are Bearer-token-gated by default (the router
+    gates them unless ``@noauth()``). Reads (GET) are public by default, so no
+    decorator is emitted for them. ``--public`` re-adds ``@noauth()`` on the
+    write handlers as the explicit opt-out — mirroring AutoCrud's ``public=True``
+    (tina4_python/crud/__init__.py: secure-by-default write routes).
     """
     route_path = name.lstrip("/")
     singular = route_path.rstrip("s") if route_path.endswith("s") else route_path
     model = flags.get("model", "")
+    public = bool(flags.get("public"))
 
     target = Path("src/routes")
     target.mkdir(parents=True, exist_ok=True)
@@ -813,17 +919,36 @@ def _gen_route(name: str, flags: dict):
         print(f"  ✗ File already exists: {path}")
         return
 
-    # Import line
-    imports = "from tina4_python.core.router import get, post, put, delete, noauth\n"
+    # ``@noauth()`` is only imported/emitted when the caller opts writes public.
+    w = "@noauth()\n" if public else ""  # write-handler auth decorator (opt-in)
+    router_imports = "get, post, put, delete, noauth" if public else "get, post, put, delete"
+
+    imports = f"from tina4_python.core.router import {router_imports}\n"
     imports += "from tina4_python.swagger import description, tags\n"
     if model:
         imports += f"from src.orm.{model} import {model}\n"
 
+    # Secure-by-default posture note for the WRITE handler docstrings.
+    write_doc = (
+        "Public (--public): no token required."
+        if public else
+        "Secure-by-default: requires a Bearer token (use --public to open)."
+    )
+
     # Route handlers
     if model:
+        # WORKING code (the boilerplate IS the feature) + EXTEND markers at the
+        # natural extension points (no NotImplementedError).
+        ext_create = _extend(
+            "validate / business rules before persist",
+            'e.g. reject invalid input; ground: tina4_context("validate before create", "python")',
+        )
+        ext_update = _extend(
+            "guard which fields / who may update",
+            'e.g. enforce ownership; ground: tina4_context("authorize update", "python")',
+        )
         content = f'''{imports}
 
-@noauth()
 @description("List all {route_path}")
 @tags(["{route_path}"])
 @get("/api/{route_path}")
@@ -842,7 +967,6 @@ async def list_{route_path}(request, response):
     }})
 
 
-@noauth()
 @description("Get a {singular} by ID")
 @tags(["{route_path}"])
 @get("/api/{route_path}/{{id:int}}")
@@ -854,36 +978,35 @@ async def get_{singular}(request, response):
     return response({singular}.to_dict())
 
 
-@noauth()
-@description("Create a new {singular}")
+{w}@description("Create a new {singular}")
 @tags(["{route_path}"])
 @post("/api/{route_path}")
 async def create_{singular}(request, response):
-    """Create a new {singular}."""
-    item = {model}.create(request.body)
+    """Create a new {singular}. {write_doc}"""
+{ext_create}    item = {model}.create(request.body)
     return response(item.to_dict(), 201)
 
 
-@description("Update a {singular}")
+{w}@description("Update a {singular}")
 @tags(["{route_path}"])
 @put("/api/{route_path}/{{id:int}}")
 async def update_{singular}(request, response):
-    """Update a {singular} by ID."""
+    """Update a {singular} by ID. {write_doc}"""
     item = {model}.find_by_id(request.params["id"])
     if item is None:
         return response({{"error": "Not found"}}, 404)
-    for key, value in request.body.items():
+{ext_update}    for key, value in request.body.items():
         if hasattr(item, key) and key != "id":
             setattr(item, key, value)
     item.save()
     return response(item.to_dict())
 
 
-@description("Delete a {singular}")
+{w}@description("Delete a {singular}")
 @tags(["{route_path}"])
 @delete("/api/{route_path}/{{id:int}}")
 async def delete_{singular}(request, response):
-    """Delete a {singular} by ID."""
+    """Delete a {singular} by ID. {write_doc}"""
     item = {model}.find_by_id(request.params["id"])
     if item is None:
         return response({{"error": "Not found"}}, 404)
@@ -891,50 +1014,89 @@ async def delete_{singular}(request, response):
     return response(None, 204)
 '''
     else:
+        # CUSTOM route — no model. Every handler body is a LOGIC-shaped stub:
+        # AI-FILL fill-spec + raise NotImplementedError (fails loud until filled).
+        m = "".join(p.capitalize() for p in singular.split("_"))  # PascalCase hint
+        b_list = _ai_fill(
+            f"list_{route_path}",
+            f"return the {route_path} collection (add pagination if it grows)",
+            f"{m}.all()  or  {m}.where(sql, params, with_count=True)  (import {m} from src.orm.{m})",
+            f"list_{route_path}: query and return the records",
+            ret='response({"records": [r.to_dict() for r in rows]})',
+            ground=f'tina4_context("list ORM records with pagination", "python")',
+        )
+        b_get = _ai_fill(
+            f"get_{singular}",
+            f"fetch one {singular} by id",
+            f'{m}.find_by_id(request.params["id"])  (import {m} from src.orm.{m})',
+            f"get_{singular}: fetch by id or 404",
+            given='request.params["id"] -> int',
+            ret='response(item.to_dict())  or  response({"error": "Not found"}, 404)',
+            ground='tina4_context("find ORM record by id", "python")',
+        )
+        b_create = _ai_fill(
+            f"create_{singular}",
+            f"validate the body and persist a new {singular}",
+            f"{m}.create(request.body)  (import {m} from src.orm.{m})",
+            f"create_{singular}: persist and return the new record",
+            given="request.body -> dict of fields",
+            ret="response(item.to_dict(), 201)",
+            ground='tina4_context("create ORM record and return 201", "python")',
+        )
+        b_update = _ai_fill(
+            f"update_{singular}",
+            f"load, mutate and save an existing {singular}",
+            f'{m}.find_by_id(request.params["id"])  then set fields and item.save()',
+            f"update_{singular}: apply changes and return the record",
+            given='request.params["id"] -> int; request.body -> changed fields',
+            ret="response(item.to_dict())  or  404",
+            ground='tina4_context("update ORM record", "python")',
+        )
+        b_delete = _ai_fill(
+            f"delete_{singular}",
+            f"delete a {singular} by id",
+            f'{m}.find_by_id(request.params["id"])  then item.delete()',
+            f"delete_{singular}: delete and return 204",
+            given='request.params["id"] -> int',
+            ret="response(None, 204)  or  404",
+            ground='tina4_context("delete ORM record", "python")',
+        )
         content = f'''{imports}
 
-@noauth()
 @description("List all {route_path}")
 @tags(["{route_path}"])
 @get("/api/{route_path}")
 async def list_{route_path}(request, response):
     """List all {route_path}."""
-    return response({{"data": []}})
+{b_list}
 
-
-@noauth()
 @description("Get a {singular} by ID")
 @tags(["{route_path}"])
 @get("/api/{route_path}/{{id:int}}")
 async def get_{singular}(request, response):
     """Get a single {singular}."""
-    return response({{"data": {{}}}})
+{b_get}
 
-
-@noauth()
-@description("Create a new {singular}")
+{w}@description("Create a new {singular}")
 @tags(["{route_path}"])
 @post("/api/{route_path}")
 async def create_{singular}(request, response):
-    """Create a new {singular}."""
-    return response({{"data": request.body}}, 201)
+    """Create a new {singular}. {write_doc}"""
+{b_create}
 
-
-@description("Update a {singular}")
+{w}@description("Update a {singular}")
 @tags(["{route_path}"])
 @put("/api/{route_path}/{{id:int}}")
 async def update_{singular}(request, response):
-    """Update a {singular}."""
-    return response({{"data": request.body}})
+    """Update a {singular}. {write_doc}"""
+{b_update}
 
-
-@description("Delete a {singular}")
+{w}@description("Delete a {singular}")
 @tags(["{route_path}"])
 @delete("/api/{route_path}/{{id:int}}")
 async def delete_{singular}(request, response):
-    """Delete a {singular}."""
-    return response(None, 204)
-'''
+    """Delete a {singular}. {write_doc}"""
+{b_delete}'''
 
     path.write_text(content, encoding="utf-8")
     print(f"  ✓ Created {path}")
@@ -954,8 +1116,10 @@ def _gen_crud(name: str, flags: dict):
     # 1. Model + migration
     _gen_model(name, flags)
 
-    # 2. Routes with model
-    route_flags = {"model": name}
+    # 2. Routes with model — secure-by-default; thread --public through so
+    #    `generate crud X --public` opens the writes (mirrors AutoCrud public=).
+    is_public = bool(flags.get("public"))
+    route_flags = {"model": name, "public": is_public}
     _gen_route(route_name, route_flags)
 
     # 3. Template
@@ -1004,8 +1168,8 @@ def _gen_crud(name: str, flags: dict):
     # 5. View (list + detail)
     _gen_view(name, flags)
 
-    # 6. Test
-    _gen_test(route_name, {"model": name})
+    # 6. Test — secure-by-default gate test (behavioural, real TestClient).
+    _gen_test(route_name, {"model": name, "secure_writes": True, "public": is_public})
 
     print(f"\n  CRUD generation complete for {name}.")
     print(f"  Run: tina4python migrate")
@@ -1139,6 +1303,84 @@ def _gen_test(name: str, flags: dict = None):
         print(f"  ✗ File already exists: {path}")
         return
 
+    # Secure-by-default CRUD test (emitted by `generate crud`): proves the gate
+    # by BEHAVIOR through the real TestClient — reads public, writes gated —
+    # instead of assuming an anonymous create returns 201. Grounded on
+    # tests/test_test_client_auth.py (real Router, real _check_auth, real JWT).
+    if model and flags.get("secure_writes"):
+        singular_ = singular
+        write_neg = (
+            '    def test_create___SINGULAR___requires_auth(self):\n'
+            '        """Secure by default: a tokenless POST is rejected with 401."""\n'
+            '        assert TestClient().post("/api/__SNAKE__", json={"name": "test"}).status == 401\n'
+        )
+        write_pos = (
+            '    def test_create___SINGULAR___with_token(self):\n'
+            '        """A valid Bearer token passes the gate and creates → 201."""\n'
+            '        res = TestClient().post("/api/__SNAKE__", json={"name": "test"}, headers=_auth_headers())\n'
+            "        assert res.status == 201\n"
+        )
+        if flags.get("public"):
+            # --public opened the writes: an anonymous POST must succeed (201).
+            write_neg = (
+                '    def test_create___SINGULAR___is_public(self):\n'
+                '        """--public opened the write: an anonymous POST creates → 201."""\n'
+                '        assert TestClient().post("/api/__SNAKE__", json={"name": "test"}).status == 201\n'
+            )
+            write_pos = ""
+        gate_template = (
+            '"""Tests for __NAME__ CRUD — reads public, writes __POSTURE__.\n'
+            "\n"
+            "Real end-to-end via TestClient: no mocks — real Router, real auth gate\n"
+            "(_check_auth), real JWT. A real SQLite DB + table is bound in setup so\n"
+            "the create path is exercised for real.\n"
+            '"""\n'
+            "import os\n"
+            "\n"
+            'os.environ.setdefault("TINA4_SECRET", "test-secret")\n'
+            'os.environ.pop("TINA4_API_KEY", None)\n'
+            "\n"
+            "from tina4_python.auth import get_token\n"
+            "from tina4_python.database import Database\n"
+            "from tina4_python.orm.model import bind_database\n"
+            "from tina4_python.test_client import TestClient\n"
+            "from src.orm.__MODEL__ import __MODEL__\n"
+            "import src.routes.__SNAKE__  # noqa: F401 — importing registers the routes\n"
+            "\n"
+            "\n"
+            "def _auth_headers():\n"
+            '    """A valid Bearer token for the gated write routes."""\n'
+            '    return {"Authorization": f"Bearer {get_token({\'user_id\': 1})}"}\n'
+            "\n"
+            "\n"
+            "class Test__MODEL__:\n"
+            '    """__MODEL__ CRUD — reads public, writes __POSTURE__ (secure by default)."""\n'
+            "\n"
+            "    def setup_method(self, _method):\n"
+            '        bind_database(Database("sqlite:///test___SNAKE__.db"))\n'
+            "        __MODEL__.create_table()\n"
+            "\n"
+            "    def test_list___SNAKE___is_public(self):\n"
+            '        """GET is public — no token needed."""\n'
+            '        assert TestClient().get("/api/__SNAKE__").status == 200\n'
+            "\n"
+            "__WRITE_NEG__"
+            "\n"
+            "__WRITE_POS__"
+        )
+        content = (
+            gate_template.replace("__WRITE_NEG__", write_neg)
+            .replace("__WRITE_POS__", write_pos)
+            .replace("__POSTURE__", "open (--public)" if flags.get("public") else "gated")
+            .replace("__NAME__", name)
+            .replace("__MODEL__", model)
+            .replace("__SINGULAR__", singular_)
+            .replace("__SNAKE__", snake)
+        )
+        path.write_text(content, encoding="utf-8")
+        print(f"  ✓ Created {path}")
+        return
+
     if model:
         content = f'''"""Tests for {name} CRUD operations."""
 import pytest
@@ -1201,6 +1443,370 @@ class Test{name.title().replace("_", "")}:
         assert True
 '''
 
+    path.write_text(content, encoding="utf-8")
+    print(f"  ✓ Created {path}")
+
+
+# ── Scaffolding-first generators (wiring + `# your code here`) ────────
+#
+# Each grounds on the REAL current Tina4 API (verified against the source) and
+# drops the _ai_fill() AI-FILL placeholder where the custom logic goes:
+#   service   → tina4_python/service/__init__.py   ServiceRunner.register / discover
+#   queue     → tina4_python/queue/__init__.py     Queue.push / Queue.consume / Job.complete
+#   validator → tina4_python/validator/__init__.py Validator
+#   seeder    → tina4_python/seeder/__init__.py    FakeData / seed_orm
+#   websocket → tina4_python/core/router.py        @websocket (conn, event, data)
+#   listener  → tina4_python/core/events.py        @on(event)
+
+def _gen_service(name: str, flags: dict = None):
+    """Generate a scheduled background service (ServiceRunner).
+
+    tina4python generate service Cleanup --every 5m
+    tina4python generate service Report --cron "0 3 * * *"
+    """
+    flags = flags or {}
+    snake = _to_snake(name)
+    cron = flags.get("cron")
+    if cron and cron is not True:
+        schedule_reg = f'cron="{cron}"'
+        schedule_kv = f'"cron": "{cron}",'
+        schedule_note = f"cron '{cron}'"
+    else:
+        seconds = _parse_every(flags.get("every", "") if flags.get("every") is not True else "")
+        schedule_reg = f"interval={seconds}"
+        schedule_kv = f'"interval": {seconds},'
+        schedule_note = f"every {seconds}s"
+
+    target = Path("src/services")
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / f"{snake}.py"
+    if path.exists():
+        print(f"  ✗ File already exists: {path}")
+        return
+
+    body = _ai_fill(
+        f"{snake}_task",
+        "do the scheduled work for this service",
+        "context.log.info(...) to log; call your ORM / app code (re-run on schedule)",
+        f"service:{snake}: implement the scheduled task",
+        given="context -> ServiceContext (.name, .stop_event, .log)",
+        ground='tina4_context("background service scheduled task", "python")',
+    )
+    template = (
+        '"""__NAME__ background service — runs __NOTE__ via ServiceRunner.\n'
+        "\n"
+        "Wire a runner once (e.g. in app.py) to actually run it — `tina4python\n"
+        "serve` does NOT auto-start services:\n"
+        "\n"
+        "    from tina4_python.service import ServiceRunner\n"
+        "    runner = ServiceRunner()\n"
+        '    register(runner)              # or: runner.discover("src/services")\n'
+        "    runner.start()\n"
+        '"""\n'
+        "from tina4_python.service import ServiceRunner\n"
+        "\n"
+        "\n"
+        "def __SNAKE___task(context):\n"
+        '    """The scheduled task body. `context` is a ServiceContext with\n'
+        "    .name, .stop_event and .log; a daemon-style task would loop until\n"
+        '    context.stop_event.is_set()."""\n'
+        "__BODY__"
+        "\n\n"
+        "def register(runner: ServiceRunner) -> None:\n"
+        '    """Register this service on a ServiceRunner."""\n'
+        '    runner.register("__SNAKE__", __SNAKE___task, __SCHEDULE_REG__)\n'
+        "\n"
+        "\n"
+        '# Discovered by ServiceRunner.discover("src/services"), which calls\n'
+        "# register(name=, handler=, interval=/cron=) from these keys.\n"
+        "service = {\n"
+        '    "name": "__SNAKE__",\n'
+        '    "handler": __SNAKE___task,\n'
+        "    __SCHEDULE_KV__\n"
+        "}\n"
+    )
+    content = (
+        template.replace("__BODY__", body)
+        .replace("__NAME__", name)
+        .replace("__NOTE__", schedule_note)
+        .replace("__SCHEDULE_REG__", schedule_reg)
+        .replace("__SCHEDULE_KV__", schedule_kv)
+        .replace("__SNAKE__", snake)
+    )
+    path.write_text(content, encoding="utf-8")
+    print(f"  ✓ Created {path}")
+
+
+def _gen_queue(name: str, flags: dict = None):
+    """Generate a queue producer + consumer worker.
+
+    tina4python generate queue order-emails
+    """
+    topic = name.lstrip("/")
+    slug = _to_snake(re.sub(r"[^0-9a-zA-Z]+", "_", topic)).strip("_") or "topic"
+
+    target = Path("src/services")  # consumer runs as a daemon service (see below)
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / f"{slug}_consumer.py"
+    if path.exists():
+        print(f"  ✗ File already exists: {path}")
+        return
+
+    body = _ai_fill(
+        f"handle_{slug}",
+        f"process ONE {topic} job payload",
+        "your ORM / Messenger() code; return to ack (job.complete), raise to nack (job.fail)",
+        f"queue:{topic}: process the job payload",
+        given="data -> dict (the pushed Job.data)",
+        ground='tina4_context("process a queue job", "python")',
+    )
+    template = (
+        '"""__TOPIC__ queue — producer + consumer worker.\n'
+        "\n"
+        "Produce from anywhere:   publish___SLUG__({...})\n"
+        "The consumer is a long-running worker wired as a daemon `service` so\n"
+        '    ServiceRunner().discover("src/services") + runner.start()\n'
+        "runs it without blocking boot (consume() is an endless generator).\n"
+        '"""\n'
+        "from tina4_python.queue import Queue\n"
+        "\n"
+        "\n"
+        "def publish___SLUG__(data: dict):\n"
+        '    """Enqueue a __TOPIC__ job for the worker below to process."""\n'
+        '    return Queue(topic="__TOPIC__").push(data)\n'
+        "\n"
+        "\n"
+        "def handle___SLUG__(data: dict):\n"
+        '    """Process ONE __TOPIC__ job payload (`data` is Job.data — the pushed dict)."""\n'
+        "__BODY__"
+        "\n\n"
+        "def consume___SLUG__(context=None):\n"
+        '    """Long-running __TOPIC__ worker. consume() yields Jobs; ack with\n'
+        "    job.complete(), nack with job.fail(). `context` is the ServiceContext\n"
+        '    when run under ServiceRunner (unused here)."""\n'
+        '    for job in Queue(topic="__TOPIC__").consume():\n'
+        "        try:\n"
+        "            handle___SLUG__(job.data)\n"
+        "            job.complete()          # ack — job done, remove from the queue\n"
+        "        except Exception as exc:    # noqa: BLE001\n"
+        "            job.fail(str(exc))      # nack — retry / dead-letter\n"
+        "\n"
+        "\n"
+        '# Discovered by ServiceRunner.discover("src/services"); daemon=True because\n'
+        "# consume___SLUG__ manages its own loop.\n"
+        'service = {"name": "__TOPIC__-consumer", "handler": consume___SLUG__, "daemon": True}\n'
+    )
+    content = (
+        template.replace("__BODY__", body)
+        .replace("__TOPIC__", topic)
+        .replace("__SLUG__", slug)
+    )
+    path.write_text(content, encoding="utf-8")
+    print(f"  ✓ Created {path}")
+
+
+def _gen_validator(name: str, flags: dict = None):
+    """Generate a request-body validator.
+
+    tina4python generate validator CreateUser
+    """
+    snake = _to_snake(name)
+    target = Path("src/validators")
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / f"{snake}.py"
+    if path.exists():
+        print(f"  ✗ File already exists: {path}")
+        return
+
+    body = _ai_fill(
+        f"validate_{snake}",
+        f"declare the validation rules for a {name} payload",
+        'validator.required("name").email("email").min_length("name", 2).integer("age")',
+        f"validator:{snake}: add the rule set",
+        given="validator -> Validator(data) (chainable)",
+        ret="the same validator (caller checks .is_valid() / .errors())",
+        ground='tina4_context("validate request body with Validator", "python")',
+    )
+    template = (
+        '"""__NAME__ request validator."""\n'
+        "from tina4_python.validator import Validator\n"
+        "\n"
+        "\n"
+        "def validate___SNAKE__(data: dict) -> Validator:\n"
+        '    """Validate a __NAME__ payload. Returns a Validator (chainable rules).\n'
+        "\n"
+        "    Usage in a route::\n"
+        "\n"
+        "        v = validate___SNAKE__(request.body)\n"
+        "        if not v.is_valid():\n"
+        '            return response.error("VALIDATION_FAILED", v.errors()[0]["message"], 400)\n'
+        '    """\n'
+        "    validator = Validator(data)\n"
+        "__BODY__"
+        "    return validator\n"
+    )
+    content = (
+        template.replace("__BODY__", body)
+        .replace("__NAME__", name)
+        .replace("__SNAKE__", snake)
+    )
+    path.write_text(content, encoding="utf-8")
+    print(f"  ✓ Created {path}")
+
+
+def _gen_seeder(name: str, flags: dict = None):
+    """Generate a seeder for an ORM model.
+
+    tina4python generate seeder Product
+    """
+    table = _to_table(name)
+    target = Path("src/seeds")
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / f"{table}_seeder.py"
+    if path.exists():
+        print(f"  ✗ File already exists: {path}")
+        return
+
+    body = _ai_fill(
+        "field_overrides",
+        f"map {name} fields to fake-data generators (only those needing a specific shape)",
+        "fake.name() / fake.email() / fake.integer(1, 99) / fake.company()  (FakeData)",
+        f"seeder:{name}: return the field->generator overrides",
+        given="fake -> FakeData instance",
+        ret='{"email": lambda fake: fake.email(), "status": "active"}  (dict)',
+        ground='tina4_context("seed ORM model with FakeData", "python")',
+    )
+    template = (
+        '"""Seeder for __NAME__ — run with: tina4python seed"""\n'
+        "from tina4_python.seeder import FakeData, seed_orm\n"
+        "from src.orm.__NAME__ import __NAME__\n"
+        "\n"
+        "\n"
+        "def field_overrides(fake: FakeData) -> dict:\n"
+        '    """Map __NAME__ fields → FakeData generators (or static values).\n'
+        "\n"
+        "    seed_orm auto-fills every field by type/name; override the ones that\n"
+        "    need a specific shape here. Each callable receives a FakeData instance:\n"
+        '        return {"email": lambda fake: fake.email(), "status": "active"}\n'
+        '    """\n'
+        "__BODY__"
+        "\n\n"
+        "def run(db):\n"
+        '    """Seed rows. Invoked by `tina4python seed` (passes the Database)."""\n'
+        "    fake = FakeData()\n"
+        "    summary = seed_orm(__NAME__, count=20, overrides=field_overrides(fake))\n"
+        '    print(f"Seeded {summary.seeded} __NAME__ row(s), {summary.failed} failed")\n'
+    )
+    content = template.replace("__BODY__", body).replace("__NAME__", name)
+    path.write_text(content, encoding="utf-8")
+    print(f"  ✓ Created {path}")
+
+
+def _gen_websocket(name: str, flags: dict = None):
+    """Generate a WebSocket route.
+
+    tina4python generate websocket chat
+    tina4python generate websocket /ws/rooms/{id}
+    """
+    raw = name.strip()
+    ws_path = raw if raw.startswith("/") else "/ws/" + raw.lstrip("/")
+    slug = _to_snake(re.sub(r"[^0-9a-zA-Z]+", "_", raw.strip("/"))).strip("_") or "ws"
+    base = slug[3:] if slug.startswith("ws_") else slug
+    base = base or "ws"
+    handler = f"{base}_ws"
+
+    target = Path("src/routes")  # @websocket auto-registers on import (src/ is discovered)
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / f"ws_{base}.py"
+    if path.exists():
+        print(f"  ✗ File already exists: {path}")
+        return
+
+    body = _ai_fill(
+        handler,
+        f'handle an inbound "message" frame on {ws_path}',
+        "await connection.broadcast(data)  or  await connection.send_json({...})",
+        f"websocket:{ws_path}: handle the inbound message",
+        given="data -> str (message payload); connection -> WebSocketConnection",
+        ground='tina4_context("websocket broadcast message", "python")',
+    )
+    template = (
+        '"""__WSPATH__ WebSocket route.\n'
+        "\n"
+        "Auto-registered on import by @websocket (src/ is auto-discovered at boot).\n"
+        "The server invokes the handler as handler(connection, event, data) for\n"
+        'each event: "open" (connect), "message" (inbound frame), "close"\n'
+        "(disconnect). Put @secured() above @websocket to require a JWT on the\n"
+        "upgrade; connection.broadcast()/connection.send() reach the other clients.\n"
+        '"""\n'
+        "from tina4_python.core.router import websocket\n"
+        "\n"
+        "\n"
+        '@websocket("__WSPATH__")\n'
+        "async def __HANDLER__(connection, event, data):\n"
+        '    """__WSPATH__ handler. `data` is the message payload on "message",\n'
+        '    None on "open"/"close"; connection.params holds any path params."""\n'
+        '    if event == "open":\n'
+        '        await connection.send(\'{"type": "welcome"}\')\n'
+        "        return\n"
+        '    if event == "close":\n'
+        "        return\n"
+        '    # event == "message"\n'
+        "__BODY__"
+    )
+    content = (
+        template.replace("__BODY__", body)
+        .replace("__WSPATH__", ws_path)
+        .replace("__HANDLER__", handler)
+    )
+    path.write_text(content, encoding="utf-8")
+    print(f"  ✓ Created {path}")
+
+
+def _gen_listener(name: str, flags: dict = None):
+    """Generate an event listener.
+
+    tina4python generate listener user.created
+    """
+    event = name.strip()
+    slug = _to_snake(re.sub(r"[^0-9a-zA-Z]+", "_", event)).strip("_") or "event"
+
+    target = Path("src/listeners")  # @on auto-registers on import (src/ is discovered)
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / f"{slug}.py"
+    if path.exists():
+        print(f"  ✗ File already exists: {path}")
+        return
+
+    body = _ai_fill(
+        f"on_{slug}",
+        f"react to the '{event}' event",
+        "your app code — Messenger().send(...), an ORM write, or emit(...) a follow-up event",
+        f"listener:{event}: react to the event payload",
+        given=f"data -> whatever emit('{event}', data) passed",
+        ground='tina4_context("event listener reaction", "python")',
+    )
+    template = (
+        "\"\"\"Listener for the '__EVENT__' event.\n"
+        "\n"
+        "Auto-registered on import by @on (src/ is auto-discovered at boot). Fires\n"
+        'when something calls emit("__EVENT__", data). Listeners are isolated — a\n'
+        "raise is logged and the other listeners still run (emit(..., strict=True)\n"
+        "re-raises instead).\n"
+        '"""\n'
+        "from tina4_python.core.events import on\n"
+        "\n"
+        "\n"
+        '@on("__EVENT__")\n'
+        "def on___SLUG__(data=None):\n"
+        "    \"\"\"React to '__EVENT__'. `data` is whatever emit('__EVENT__', data) passed.\"\"\"\n"
+        "__BODY__"
+    )
+    content = (
+        template.replace("__BODY__", body)
+        .replace("__EVENT__", event)
+        .replace("__SLUG__", slug)
+    )
     path.write_text(content, encoding="utf-8")
     print(f"  ✓ Created {path}")
 


### PR DESCRIPTION
Ships the scaffolding-first initiative for tina4-python (3.13.64).

- `generate route`/`crud` no longer emit `@noauth()` on scaffolded reads or create — writes are **secure-by-default** (router token-gates POST/PUT/DELETE); `--public` opts writes out only, mirroring AutoCrud's `public=True`. `generate auth` stays public (login/register).
- **AI-FILL** placeholder convention for logic stubs: `Intent/Given/Use/Return/Ground` fill-spec + `raise NotImplementedError` (fails loud); working CRUD gets a lighter `EXTEND` marker.
- **6 new generators**: service, queue, validator, seeder, websocket, listener — grounded in live source.
- Real boot-gate tests (no mocks): anon write→401, token→201, anon read→200; placeholder raises when called; wiring registered on the real Router/ServiceRunner/event bus.
- Dev skill + `llms.txt` now lead with scaffolding.

Full suite: 3354 passed / 0 failed (independently re-run). 58 scaffolding tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)