### PR TITLE
feat(cli): self-describing `commands` subcommand + single-source command registry

### DIFF
--- a/plan/self-describing-client.md
+++ b/plan/self-describing-client.md
@@ -1,0 +1,56 @@
+# Task: Self-describing CLI — `commands` subcommand (Phase 1, Python master)
+
+## Goal
+Give the Tina4 Python CLI a `commands` subcommand that emits its own command
+surface — human-readable (`tina4python commands`) and machine-readable
+(`tina4python commands --json`) — so the Rust `tina4` client can DISCOVER what
+this framework supports instead of hardcoding it.
+
+## Context
+Today three copies of the same knowledge live in `tina4_python/cli/__init__.py`
+and drift independently:
+1. the `commands = {name: handler}` dispatch dict inside `main()` (~L202)
+2. the hand-written help block in `_help()` (~L276)
+3. the `generators = {name: fn}` dict inside `_generate()` (~L817)
+
+The epic's whole point is: ONE registry, no drift.
+
+## Scope
+- [x] Ground with `tina4_context("cli internals", "python")` + read live source
+- [x] Lift the generator dispatch dict to a module-level `GENERATORS` registry
+      (name -> {handler, usage, summary}); `_generate` dispatches from it
+- [x] Add a module-level `COMMANDS` registry (name -> {handler, summary, usage?,
+      args?, subcommands?}) as the single source of truth
+- [x] `main()` dispatches from `COMMANDS`
+- [x] `_help()` is generated from `COMMANDS` + `GENERATORS` (no hand-written list)
+- [x] `_commands_manifest()` builds the JSON manifest from `COMMANDS`
+- [x] `_commands()` handler: prints human list, or `--json` manifest. CHEAP +
+      side-effect-free (no bootstrap / DB / migrations / app imports)
+- [x] Real test `tests/test_cli_commands_manifest.py` (no mocks): in-process
+      content assertions + real subprocess `commands --json` in a temp dir with
+      NO `TINA4_DATABASE_URL` and no `migrations/` (app/DB-free proof)
+
+## Manifest shape (exact keys)
+```
+{ "framework": "python", "version": "<tina4_python.__version__>",
+  "commands": [ {"name","summary", "args"?, "subcommands"?}, ... ] }
+```
+Truthful to the real command set: init, serve, start, migrate, migrate:create,
+migrate:rollback, migrate:status, env-migrate, seed, routes, test, build, ai,
+generate, console, metrics, help, commands. `generate.subcommands` derived from
+`GENERATORS`. No invented commands (no top-level `queue` yet).
+
+## Tests (real — no mocks)
+- [x] in-process: framework=="python", version non-empty, commands non-empty,
+      every entry has name+summary, generate has subcommands incl model+crud,
+      known commands all present
+- [x] subprocess `commands --json` exits 0 with valid JSON in a clean temp dir
+      with no DB url and no migrations/ (proves no bootstrap); creates no *.db
+
+## Decision: FULL single-registry refactor (not the minimal fallback)
+Dispatch, help, and the manifest all read from `COMMANDS` (+ `GENERATORS` for
+the generate subcommands). No residual fourth list.
+
+## Status: DONE (Python master) — verified green: new test 11/11, full suite
+3365 passed / 125 skipped / 0 failed on macOS, Python 3.13 (SQLite). Parity
+mirror to PHP/Ruby/Node is a later phase of the epic.

--- a/tests/test_cli_commands_manifest.py
+++ b/tests/test_cli_commands_manifest.py
@@ -1,0 +1,142 @@
+"""Real tests for the self-describing `commands` CLI subcommand.
+
+No mocks. These exercise the ACTUAL CLI code path two ways:
+
+  * in-process — the real `_commands` handler and `_commands_manifest` builder,
+    asserting the manifest's shape and that it is DERIVED from the single-source
+    COMMANDS / GENERATORS registries (so it can never drift from dispatch);
+  * as a real subprocess running the `tina4python` entrypoint (`main`) in a
+    clean temp dir with NO database configured — proving `commands --json` is
+    cheap and side-effect-free (no bootstrap, no DB, no migrations). This is the
+    contract the tina4 Rust client relies on when it calls the command on every
+    `tina4 --help`, in any directory.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+from tina4_python import __version__
+from tina4_python.cli import _commands, _commands_manifest, COMMANDS, GENERATORS
+
+# The command set the tina4 client must be able to discover truthfully.
+KNOWN_COMMANDS = {"migrate", "migrate:create", "seed", "test", "routes", "generate", "commands"}
+
+
+def _manifest_from_handler(capsys) -> dict:
+    """Run the REAL `commands --json` handler and parse the JSON it prints."""
+    _commands(["--json"])
+    return json.loads(capsys.readouterr().out)
+
+
+class TestCommandsManifestContent:
+    """The manifest emitted by `commands --json`, asserted in-process."""
+
+    def test_handler_json_matches_builder(self, capsys):
+        """The --json handler prints exactly the manifest the builder returns."""
+        assert _manifest_from_handler(capsys) == _commands_manifest()
+
+    def test_framework_is_python(self, capsys):
+        assert _manifest_from_handler(capsys)["framework"] == "python"
+
+    def test_version_is_nonempty_and_versionish(self, capsys):
+        version = _manifest_from_handler(capsys)["version"]
+        assert isinstance(version, str) and version.strip()
+        assert re.match(r"^\d+\.\d+", version), f"not version-looking: {version!r}"
+        assert version == __version__
+
+    def test_commands_is_nonempty_and_well_formed(self, capsys):
+        commands = _manifest_from_handler(capsys)["commands"]
+        assert isinstance(commands, list) and commands
+        for entry in commands:
+            assert entry.get("name"), f"entry missing name: {entry}"
+            assert entry.get("summary"), f"entry missing summary: {entry}"
+
+    def test_known_commands_all_present(self, capsys):
+        names = {c["name"] for c in _manifest_from_handler(capsys)["commands"]}
+        missing = KNOWN_COMMANDS - names
+        assert not missing, f"manifest missing commands: {missing}"
+
+    def test_manifest_lists_exactly_the_dispatchable_commands(self, capsys):
+        """Anti-drift lock-in: the manifest is DERIVED from the dispatch registry,
+        so it lists exactly what `main()` can dispatch — no separate list."""
+        names = [c["name"] for c in _manifest_from_handler(capsys)["commands"]]
+        assert names == list(COMMANDS)
+
+    def test_generate_has_subcommands_with_model_and_crud(self, capsys):
+        generate = next(
+            c for c in _manifest_from_handler(capsys)["commands"] if c["name"] == "generate"
+        )
+        subcommands = generate.get("subcommands")
+        assert isinstance(subcommands, list) and subcommands
+        assert {"model", "crud"} <= set(subcommands)
+        # Derived from the GENERATORS registry — never a hand-kept fourth list.
+        assert subcommands == list(GENERATORS)
+
+    def test_migrate_create_declares_its_positional_arg(self, capsys):
+        entry = next(
+            c for c in _manifest_from_handler(capsys)["commands"] if c["name"] == "migrate:create"
+        )
+        assert entry.get("args") == ["description"]
+
+    def test_no_invented_top_level_queue_command(self, capsys):
+        """`queue` is a later phase: it must NOT appear as a top-level command
+        (it exists only as a `generate` subcommand today)."""
+        names = {c["name"] for c in _manifest_from_handler(capsys)["commands"]}
+        assert "queue" not in names
+        assert "queue" in list(GENERATORS)
+
+
+class TestCommandsHumanOutput:
+    """The default (non-JSON) `commands` output is a readable list."""
+
+    def test_lists_every_command_name(self, capsys):
+        _commands([])
+        out = capsys.readouterr().out
+        for name in COMMANDS:
+            assert name in out, f"human output omits {name!r}"
+
+
+# The real entrypoint, driven exactly as the tina4 client would drive it.
+_ENTRYPOINT_CODE = (
+    "import sys\n"
+    "sys.argv = ['tina4python', 'commands', '--json']\n"
+    "from tina4_python.cli import main\n"
+    "main()\n"
+)
+
+
+class TestCommandsIsAppAndDbFree:
+    """Real subprocess: `commands --json` must run with NO database configured,
+    in an empty project dir (no migrations/), exit 0 fast with valid JSON, and
+    open no database — proving it never bootstraps the framework."""
+
+    def _run(self, cwd):
+        env = os.environ.copy()
+        env.pop("TINA4_DATABASE_URL", None)  # no DB configured at all
+        # A genuinely fresh process — import-time must not bootstrap / migrate /
+        # open a DB. A 60s ceiling is generous for a cold import; a bootstrap
+        # attempt would either error (non-zero) or hang past it.
+        return subprocess.run(
+            [sys.executable, "-c", _ENTRYPOINT_CODE],
+            cwd=str(cwd), env=env,
+            capture_output=True, text=True, timeout=60,
+        )
+
+    def test_exits_zero_with_valid_json_and_no_db(self, tmp_path):
+        assert not (tmp_path / "migrations").exists()
+        assert not (tmp_path / "app.py").exists()
+
+        result = self._run(tmp_path)
+
+        assert result.returncode == 0, f"non-zero exit; stderr:\n{result.stderr}"
+        manifest = json.loads(result.stdout)  # raises if not valid JSON
+        assert manifest["framework"] == "python"
+        assert manifest["version"].strip()
+        assert any(c["name"] == "commands" for c in manifest["commands"])
+        assert any(c["name"] == "generate" for c in manifest["commands"])
+
+        # No SQLite file anywhere under the project dir — nothing opened a DB.
+        created_dbs = list(tmp_path.rglob("*.db"))
+        assert created_dbs == [], f"commands opened/created a database: {created_dbs}"

--- a/tina4_python/cli/__init__.py
+++ b/tina4_python/cli/__init__.py
@@ -199,29 +199,12 @@ def main():
     command = args[0].lower()
     cmd_args = args[1:]
 
-    commands = {
-        "init": _init,
-        "serve": _serve,
-        "start": _serve,
-        "migrate": _migrate,
-        "migrate:create": _migrate_create,
-        "migrate:rollback": _migrate_rollback,
-        "migrate:status": _migrate_status,
-        "env-migrate": _env_migrate,
-        "seed": _seed,
-        "routes": _routes,
-        "test": _test,
-        "build": _build,
-        "ai": _ai,
-        "generate": _generate,
-        "console": _console,
-        "metrics": _metrics,
-        "help": _help,
-    }
-
-    handler = commands.get(command)
-    if handler:
-        handler(cmd_args)
+    # Dispatch from the single-source-of-truth COMMANDS registry (defined at the
+    # bottom of this module). The same registry drives `_help` and the
+    # `commands --json` manifest, so dispatch, help, and discovery never drift.
+    spec = COMMANDS.get(command)
+    if spec:
+        spec["handler"](cmd_args)
     else:
         print(f"Unknown command: {command}")
         _help([])
@@ -274,53 +257,45 @@ def _env_migrate(args):
 
 
 def _help(args=None):
-    print("""
-Tina4 Python — CLI
+    """Print the human-readable command reference.
 
-Usage: tina4python <command> [options]
+    Generated from the COMMANDS and GENERATORS registries — the SAME single
+    source of truth that drives dispatch (`main`) and the `commands --json`
+    manifest — so the help text can never drift from what the CLI actually does.
+    """
+    command_rows = [
+        (f"{name} {spec.get('usage', '')}".rstrip(), spec["summary"])
+        for name, spec in COMMANDS.items()
+    ]
+    generator_rows = [
+        (f"generate {name} {spec.get('usage', '')}".rstrip(), spec["summary"])
+        for name, spec in GENERATORS.items()
+    ]
+    # Align summaries in a column; a left cell longer than the cap overflows
+    # cleanly (2-space gap) rather than pushing every other summary out.
+    pad = min(46, max(len(left) for left, _ in command_rows + generator_rows))
 
-Commands:
-  init [dir]                    Scaffold a new project
-  serve [--port P] [--no-browser] [--no-reload]  Start dev server (default: 0.0.0.0:7146)
-  migrate                      Run pending database migrations
-  migrate:create <desc>         Create a new migration file
-  migrate:rollback              Rollback last migration batch
-  migrate:status                Show migration status
-  env-migrate [path]            Rewrite .env to TINA4_-prefixed names (v3.12 migration)
-  seed                          Run database seeders
-  routes                        List all registered routes
-  test                          Run test suite
-  build                         Build distributable package
-  ai [--all]                    Install AI coding assistant context
-  console                       Start interactive REPL with framework loaded
-  metrics [--top N] [--json] [--fail-on warn|error] [--path DIR]  Rank top code-quality offenders
+    def row(left, summary):
+        gap = pad if len(left) <= pad else len(left)
+        return f"  {left:<{gap}}  {summary}"
 
-Generators:
-  generate model <Name> [--fields "name:string,price:float"]
-  generate route <name> [--model Name] [--public]   Writes secure by default; --public opens them
-  generate crud <Name> [--fields "..."] [--public]   Model + migration + routes + form + view + test
-  generate migration <description>
-  generate middleware <Name>
-  generate test <name>
-  generate form <Name> [--fields "..."]   Form template with inputs matching model fields
-  generate view <Name> [--fields "..."]   List + detail templates for viewing records
-  generate auth                           Login/register/logout routes + User model + templates
-  generate service <Name> [--every 5m | --cron "..."]   Scheduled ServiceRunner task (src/services/)
-  generate queue <topic>                  Producer + consumer worker (src/services/)
-  generate validator <Name>               Request-body Validator (src/validators/)
-  generate seeder <Model>                 FakeData + seed_orm seeder (src/seeds/)
-  generate websocket <path>               @websocket handler (src/routes/)
-  generate listener <event>               @on(event) listener (src/listeners/)
-
-Scaffolding-first: logic-shaped generators emit wiring + an AI-FILL placeholder
-(raise NotImplementedError) where the custom logic goes; CRUD-shaped ones emit
-working code. Writes are secure by default — use --public to open them.
-
-Field types: string, int, float, bool, text, datetime, blob
-Table names: singular by default (Product → product)
-
-https://tina4.com
-""")
+    lines = ["", "Tina4 Python — CLI", "", "Usage: tina4python <command> [options]", "", "Commands:"]
+    lines += [row(left, summary) for left, summary in command_rows]
+    lines += ["", "Generators:"]
+    lines += [row(left, summary) for left, summary in generator_rows]
+    lines += [
+        "",
+        "Scaffolding-first: logic-shaped generators emit wiring + an AI-FILL placeholder",
+        "(raise NotImplementedError) where the custom logic goes; CRUD-shaped ones emit",
+        "working code. Writes are secure by default — use --public to open them.",
+        "",
+        "Field types: string, int, float, bool, text, datetime, blob",
+        "Table names: singular by default (Product → product)",
+        "",
+        "https://tina4.com",
+        "",
+    ]
+    print("\n".join(lines))
 
 
 # ── Console ───────────────────────────────────────────────────────────
@@ -793,8 +768,7 @@ def _generate(args):
     single ``# your code here`` placeholder (``raise NotImplementedError``) where
     the custom logic goes, so an unfilled scaffold fails loud.
     """
-    _all = ("model, route, crud, migration, middleware, test, form, view, auth, "
-            "service, queue, validator, seeder, websocket, listener")
+    _all = ", ".join(GENERATORS)  # single source: the GENERATORS registry
     if not args:
         print("Usage: tina4python generate <what> <name> [options]")
         print(f"  Generators: {_all}")
@@ -814,27 +788,11 @@ def _generate(args):
     name = args[1] if len(args) > 1 else ""
     flags, _ = _parse_flags(args[2:] if len(args) > 2 else [])
 
-    generators = {
-        "model": _gen_model,
-        "route": _gen_route,
-        "crud": _gen_crud,
-        "migration": _gen_migration,
-        "middleware": _gen_middleware,
-        "test": _gen_test,
-        "form": _gen_form,
-        "view": _gen_view,
-        "auth": _gen_auth,
-        "service": _gen_service,
-        "queue": _gen_queue,
-        "validator": _gen_validator,
-        "seeder": _gen_seeder,
-        "websocket": _gen_websocket,
-        "listener": _gen_listener,
-    }
-
-    gen = generators.get(what)
-    if gen:
-        gen(name, flags)
+    # Dispatch from the module-level GENERATORS registry (single source of truth
+    # for the generate subcommands; also feeds `_help` and the manifest).
+    gen_spec = GENERATORS.get(what)
+    if gen_spec:
+        gen_spec["handler"](name, flags)
     else:
         print(f"Unknown generator: {what}")
         print(f"  Available: {_all}")
@@ -2132,6 +2090,114 @@ def _load_env():
     if env_path.exists():
         from tina4_python.dotenv import load_env
         load_env(str(env_path))
+
+
+# ── Self-describing command surface ───────────────────────────────────
+
+def _commands_manifest() -> dict:
+    """Build the machine-readable manifest of the CLI's command surface.
+
+    Pure data: reads the module-level COMMANDS registry and the framework
+    version — no bootstrap, no database, no migrations, no app imports. This is
+    exactly what `commands --json` serializes and what the tina4 Rust client
+    consumes to discover which commands this framework supports.
+
+    Shape::
+
+        {"framework": "python", "version": "<x.y.z>",
+         "commands": [{"name", "summary", "args"?, "subcommands"?}, ...]}
+    """
+    from tina4_python import __version__
+    commands = []
+    for command_name, spec in COMMANDS.items():
+        entry = {"name": command_name, "summary": spec["summary"]}
+        if spec.get("args"):
+            entry["args"] = list(spec["args"])
+        if spec.get("subcommands"):
+            entry["subcommands"] = list(spec["subcommands"])
+        commands.append(entry)
+    return {"framework": "python", "version": __version__, "commands": commands}
+
+
+def _commands(args=None):
+    """Emit the CLI's own command surface — the self-describing manifest.
+
+        tina4python commands           human-readable list
+        tina4python commands --json    machine-readable manifest (for the tina4 CLI)
+
+    CHEAP + side-effect-free by contract: it only prints the static COMMANDS
+    registry plus the framework version. It MUST NOT bootstrap the framework,
+    open a database, run migrations, or import app modules — the Rust client
+    calls this on `tina4 --help`, in any directory, so it must be instant and
+    safe to run anywhere.
+    """
+    args = args or []
+    manifest = _commands_manifest()
+
+    if "--json" in args:
+        import json
+        print(json.dumps(manifest, indent=2))
+        return
+
+    print(f"\nTina4 {manifest['framework']} — {manifest['version']}\n")
+    width = max(len(command["name"]) for command in manifest["commands"])
+    for command in manifest["commands"]:
+        print(f"  {command['name']:<{width}}  {command['summary']}")
+        if command.get("subcommands"):
+            print(f"  {'':<{width}}    {', '.join(command['subcommands'])}")
+    print()
+
+
+# ── Command registries — the single source of truth ───────────────────
+#
+# One entry per command drives dispatch (main / _generate), the human help
+# (_help), AND the machine-readable manifest (commands --json). Add a command
+# in ONE place and it appears everywhere — there is no second list to sync.
+#
+#   GENERATORS[name] = {"handler": fn(name, flags), "usage": str, "summary": str}
+#   COMMANDS[name]   = {"handler": fn(args), "summary": str,
+#                       "usage"?: str,          # arg/flag hint for _help (human only)
+#                       "args"?: [str],         # positional args for the manifest ("x?" = optional)
+#                       "subcommands"?: [str]}  # sub-names for the manifest (generate)
+
+GENERATORS = {
+    "model":      {"handler": _gen_model,      "usage": '<Name> [--fields "name:string,price:float"]', "summary": "ORM model + matching migration"},
+    "route":      {"handler": _gen_route,      "usage": "<name> [--model Name] [--public]",            "summary": "CRUD route file, secure by default (--public opens writes)"},
+    "crud":       {"handler": _gen_crud,       "usage": '<Name> [--fields "..."] [--public]',          "summary": "Model + migration + routes + form + view + test"},
+    "migration":  {"handler": _gen_migration,  "usage": "<description>",                               "summary": "Timestamped migration file (UP/DOWN)"},
+    "middleware": {"handler": _gen_middleware, "usage": "<Name>",                                      "summary": "Middleware with before/after hooks"},
+    "test":       {"handler": _gen_test,       "usage": "<name> [--model Name]",                       "summary": "pytest test file"},
+    "form":       {"handler": _gen_form,       "usage": '<Name> [--fields "..."]',                     "summary": "Form template with inputs matching model fields"},
+    "view":       {"handler": _gen_view,       "usage": '<Name> [--fields "..."]',                     "summary": "List + detail view templates"},
+    "auth":       {"handler": _gen_auth,       "usage": "",                                            "summary": "Login/register routes + User model + templates"},
+    "service":    {"handler": _gen_service,    "usage": '<Name> [--every 5m | --cron "..."]',          "summary": "Scheduled ServiceRunner task (src/services/)"},
+    "queue":      {"handler": _gen_queue,      "usage": "<topic>",                                     "summary": "Producer + consumer worker (src/services/)"},
+    "validator":  {"handler": _gen_validator,  "usage": "<Name>",                                      "summary": "Request-body Validator (src/validators/)"},
+    "seeder":     {"handler": _gen_seeder,     "usage": "<Model>",                                     "summary": "FakeData + seed_orm seeder (src/seeds/)"},
+    "websocket":  {"handler": _gen_websocket,  "usage": "<path>",                                      "summary": "@websocket handler (src/routes/)"},
+    "listener":   {"handler": _gen_listener,   "usage": "<event>",                                     "summary": "@on(event) listener (src/listeners/)"},
+}
+
+COMMANDS = {
+    "init":             {"handler": _init,             "usage": "[dir]",  "args": ["dir?"],        "summary": "Scaffold a new project"},
+    "serve":            {"handler": _serve,            "usage": "[--port P] [--no-browser] [--no-reload]", "summary": "Start dev server (default: 0.0.0.0:7146)"},
+    "start":            {"handler": _serve,            "summary": "Alias for serve"},
+    "migrate":          {"handler": _migrate,          "summary": "Run pending database migrations"},
+    "migrate:create":   {"handler": _migrate_create,   "usage": "<desc>", "args": ["description"], "summary": "Create a new migration file"},
+    "migrate:rollback": {"handler": _migrate_rollback, "summary": "Rollback last migration batch"},
+    "migrate:status":   {"handler": _migrate_status,   "summary": "Show migration status"},
+    "env-migrate":      {"handler": _env_migrate,      "usage": "[path]", "args": ["path?"],       "summary": "Rewrite .env to TINA4_-prefixed names (v3.12 migration)"},
+    "seed":             {"handler": _seed,             "summary": "Run database seeders"},
+    "routes":           {"handler": _routes,           "summary": "List all registered routes"},
+    "test":             {"handler": _test,             "summary": "Run test suite"},
+    "build":            {"handler": _build,            "summary": "Build distributable package"},
+    "ai":               {"handler": _ai,               "usage": "[--all]", "summary": "Install AI coding assistant context"},
+    "generate":         {"handler": _generate,         "usage": "<what> <name> [options]", "subcommands": list(GENERATORS), "summary": "Generate scaffolding (see Generators below)"},
+    "console":          {"handler": _console,          "summary": "Start interactive REPL with framework loaded"},
+    "metrics":          {"handler": _metrics,          "usage": "[--top N] [--json] [--fail-on warn|error] [--path DIR]", "summary": "Rank top code-quality offenders"},
+    "commands":         {"handler": _commands,         "usage": "[--json]", "summary": "List available commands (add --json for machine form)"},
+    "help":             {"handler": _help,             "summary": "Show this help"},
+}
 
 
 __all__ = ["main"]


### PR DESCRIPTION
## What & why

Phase 1 of the **self-describing-client** epic (plan: `plan/self-describing-client.md`). The Python CLI (the master) now emits its own command surface so the Rust `tina4` client can **discover** what this framework supports instead of hardcoding it:

```
tina4python commands          # human-readable list
tina4python commands --json   # machine-readable manifest
```

Manifest shape (exact keys):
```json
{ "framework": "python", "version": "<tina4_python.__version__>",
  "commands": [ { "name": "...", "summary": "...", "args"?: [...], "subcommands"?: [...] } ] }
```

## The anti-drift refactor (full single-registry, not the minimal fallback)

`tina4_python/cli/__init__.py` previously held **three** copies of the command surface that drifted independently:
1. the `commands = {name: handler}` dispatch dict inside `main()`
2. the hand-written help block in `_help()`
3. the `generators = {name: fn}` dict inside `_generate()`

This collapses them into **one source of truth**:
- `GENERATORS` registry → drives `generate` dispatch, the help "Generators" section, and the manifest's `generate.subcommands`
- `COMMANDS` registry → drives `main()` dispatch, `_help()`, and the manifest

Add a command in one place and it shows up in dispatch, help, and discovery — no second list to sync. A lock-in test asserts `manifest names == list(COMMANDS)` so a future re-introduction of a separate list fails CI.

## Cheap + side-effect-free by contract

The `commands` handler prints only the static registry + `__version__`. It never bootstraps, opens a DB, runs migrations, or imports app modules — safe/instant in any directory (the Rust client calls it on every `tina4 --help`).

## Test (no mocks)

`tests/test_cli_commands_manifest.py`:
- in-process, exercises the real `_commands` handler + `_commands_manifest` builder: framework/version/shape, known commands present, `generate` subcommands include `model`+`crud`, and the anti-drift contract;
- a **real subprocess** running the `tina4python` entrypoint (`main`) in a clean temp dir with **no `TINA4_DATABASE_URL`** and no `migrations/`, asserting exit 0 with valid JSON and that **no `*.db` file is created** (app/DB-free proof).

## Verification (macOS, Python 3.13, SQLite)

- New test: **11 passed**
- Existing CLI modules (`test_cli_generate`, `test_cli_guard`, `test_metrics_cli`): **86 passed**
- Full suite: **3365 passed, 125 skipped, 0 failed**
- `ruff` clean on both changed files (CLI file's pre-existing findings unchanged vs `origin/v3`)

Parity mirror to PHP / Ruby / Node is a later phase of the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)