### PR TITLE
ORM: add order_by to Model.where() (parity with find/all/QueryBuilder)

### DIFF
--- a/tests/test_orm_where_order_by.py
+++ b/tests/test_orm_where_order_by.py
@@ -1,0 +1,69 @@
+# Lock-in tests for Model.where(order_by=...) — v3.13.66 ORM where-ordering parity.
+#
+# where() was the only filtered finder that could not order its results
+# (find / all / QueryBuilder all could). These tests pin the new behaviour:
+#   * order_by sorts the filtered result (ASC and DESC)
+#   * omitting order_by injects NO ORDER BY (rows come back in natural order)
+#   * with_count=True still returns (rows, total) AND the COUNT query carries
+#     no ORDER BY (a leaked ORDER BY would make the ordinal form raise)
+#
+# Real SQLite, no mocks. Rows are inserted OUT OF alphabetical order so a
+# missing or extra ORDER BY is directly observable in the output.
+import pytest
+
+from tina4_python.database import Database
+from tina4_python.orm import ORM, bind_database, Field
+
+
+class WPerson(ORM):
+    table_name = "wpeople"
+    id = Field(int, primary_key=True, auto_increment=True)
+    name = Field(str)
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = Database(f"sqlite:///{tmp_path / 'where_order.db'}")
+    d.execute("CREATE TABLE wpeople (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+    # Inserted out of alphabetical order: Charlie(id=1), Alice(id=2), Bob(id=3)
+    d.execute("INSERT INTO wpeople (name) VALUES (?)", ["Charlie"])
+    d.execute("INSERT INTO wpeople (name) VALUES (?)", ["Alice"])
+    d.execute("INSERT INTO wpeople (name) VALUES (?)", ["Bob"])
+    d.commit()
+    bind_database(d)
+    yield d
+    d.close()
+
+
+def test_order_by_asc_sorts_results(db):
+    rows = WPerson.where("1=1", order_by="name ASC")
+    assert [r.name for r in rows] == ["Alice", "Bob", "Charlie"]
+
+
+def test_order_by_desc_reverses_results(db):
+    # id DESC -> 3, 2, 1 -> Bob, Alice, Charlie
+    rows = WPerson.where("1=1", order_by="id DESC")
+    assert [r.name for r in rows] == ["Bob", "Alice", "Charlie"]
+
+
+def test_without_order_by_is_unchanged(db):
+    # negative: no order_by -> no ORDER BY injected -> natural (insertion) order
+    rows = WPerson.where("1=1")
+    assert [r.name for r in rows] == ["Charlie", "Alice", "Bob"]
+
+
+def test_with_count_returns_ordered_rows_and_total(db):
+    rows, total = WPerson.where("1=1", with_count=True, order_by="name ASC")
+    assert [r.name for r in rows] == ["Alice", "Bob", "Charlie"]
+    assert total == 3
+
+
+def test_with_count_does_not_order_the_count_query(db):
+    # The COUNT query must NOT receive the ORDER BY. Proven for real via an
+    # ordinal ORDER BY: "SELECT * ... ORDER BY 2" is valid (orders by the 2nd
+    # column, name), but "SELECT COUNT(*) AS n ... ORDER BY 2" is out of range
+    # in SQLite (a single output column) and raises. If order_by ever leaks
+    # into the COUNT query, fetch_one raises here and this test goes red.
+    rows, total = WPerson.where("1=1", with_count=True, order_by="2")
+    assert [r.name for r in rows] == ["Alice", "Bob", "Charlie"]
+    assert total == 3

--- a/tina4_python/orm/model.py
+++ b/tina4_python/orm/model.py
@@ -743,7 +743,7 @@ class ORM(metaclass=ORMMeta):
 
     @classmethod
     def where(cls, filter_sql: str, params: list = None, limit: int = 20, offset: int = 0,
-              include: list[str] = None, with_count: bool = False):
+              include: list[str] = None, with_count: bool = False, order_by: str = None):
         """Query with WHERE clause — returns array of ORM objects.
 
         Two return shapes:
@@ -754,6 +754,11 @@ class ORM(metaclass=ORMMeta):
         The tuple form is for pagination UIs where the total count is
         needed alongside the page slice — saves a second query. Total
         count respects the same filter clause but ignores limit/offset.
+
+        Args:
+            order_by: ORDER BY clause (e.g. "name ASC"). Applied to the
+                result rows only; the ``with_count`` COUNT query never
+                carries an ORDER BY.
         """
         db = cls._get_db()
         table = cls._get_table()
@@ -761,6 +766,8 @@ class ORM(metaclass=ORMMeta):
         sql = f"SELECT * FROM {table} WHERE {filter_sql}"
         if cls.soft_delete:
             sql = f"SELECT * FROM {table} WHERE ({filter_sql}) AND (is_deleted = 0 OR is_deleted IS NULL)"
+        if order_by:
+            sql += f" ORDER BY {order_by}"
 
         result = db.fetch(sql, params, limit=limit, offset=offset)
         instances = [cls(row) for row in result.records]


### PR DESCRIPTION
## What

`Model.where()` was the only filtered finder that could not order its results — `find()`, `all()`, and `QueryBuilder` all can. This adds an optional `order_by` kwarg to `where()`.

## Change (`tina4_python/orm/model.py`)

- `where(...)` signature gains `order_by: str = None` at the **END** (after `with_count`) so it stays positionally backward-compatible.
- `ORDER BY {order_by}` is appended to the SELECT **only** — the `with_count` COUNT query never carries an ORDER BY.
- `order_by` is interpolated as a column expression, matching the existing accepted convention in `find()`/`all()`/`QueryBuilder` (column expressions cannot be bound as params in any driver).

## Tests — `tests/test_orm_where_order_by.py` (real SQLite, no mocks, positive + negative)

- `order_by="name ASC"` sorts; `order_by="id DESC"` reverses (rows inserted out of order)
- omitting `order_by` injects no ORDER BY (natural/insertion order preserved)
- `with_count=True` still returns `(rows, total)`
- an ordinal `ORDER BY 2` proves the COUNT query carries no ORDER BY — a leaked ORDER BY makes the single-column COUNT raise "out of range" (verified: the test goes red when the drift is injected)

## Verification

- New test: 5 passed
- Full suite at HEAD: **3369 passed, 131 skipped** (macOS, Python 3.13.5)

Reference implementation for the cross-framework parity fix (PHP / Ruby / Node PRs mirror this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)