### PR TITLE
docs(skill): add "check for Tina4 updates" to the developer skill(s)

### DIFF
--- a/.claude/skills/tina4-developer-python/SKILL.md
+++ b/.claude/skills/tina4-developer-python/SKILL.md
@@ -513,6 +513,22 @@ Always target the latest supported Python:
 Never write code that targets older versions. Use modern language features (structural pattern
 matching, `X | None` unions, `type` aliases, etc.).
 
+## Staying current: check for Tina4 updates
+
+Tina4 ships fixes and features often, and a bug the user reports may already be fixed
+upstream. When you start substantial work — or whenever a user hits a bug a newer release
+might resolve — check whether the project's Tina4 is behind the latest, then surface it.
+**Never upgrade silently:** report the delta and let the user decide (a version bump can
+change behaviour).
+
+- **Installed:** `uv pip show tina4_python` (look at `Version`). The `tina4` CLI's own
+  version: `tina4 --version`.
+- **Latest published:** `pip index versions tina4_python` (PyPI).
+- **If behind:** tell the user what changed — point them at the release notes on
+  https://tina4.com — and offer the upgrade: bump the `tina4_python` pin in
+  `pyproject.toml` then `uv sync`, or `uv pip install -U tina4_python`.
+- The `tina4` CLI self-updates with `tina4 update`; `tina4 doctor` checks your toolchain.
+
 ## Reference Files
 
 Read these when you need detailed patterns for a specific area:

--- a/.claude/skills/tina4-js/SKILL.md
+++ b/.claude/skills/tina4-js/SKILL.md
@@ -200,6 +200,21 @@ bundle is the sub-3KB headline budget.
 | **pwa** | `tina4js/pwa` | `pwa` | 1.16 KB | Runtime web-manifest injection + service-worker registration for installable/offline apps. The manifest is generated and injected as a blob at runtime; the service worker is NOT — `register()` loads `swUrl` (or `/sw.js`), and `pwa.generateServiceWorker()` emits the SW source to write to disk. |
 | **debug** | `import 'tina4js/debug'` | side-effect (auto-enables) | dev-only | Mounts a dev overlay (Ctrl+Shift+D) that tracks signals, components, routes, and API calls. Never ship to production. |
 
+## Staying current: check for tina4-js updates
+
+tina4-js ships fixes and features often, and a rendering bug the user reports may already be
+fixed upstream. When you start substantial work — or whenever a user hits a reactivity/render
+bug a newer release might resolve — check whether the project's tina4-js is behind the latest,
+then surface it. **Never upgrade silently:** report the delta and let the user decide.
+
+- **Installed vs latest:** `npm outdated tina4js` (the npm package is `tina4js`, no hyphen).
+- **If behind:** tell the user what changed — release notes on https://tina4.com — and offer
+  the upgrade: `npm install tina4js@latest`.
+- **Using the vendored IIFE bundle** (`/js/tina4js.min.js`, shipped inside the Tina4 backend
+  via tina4-css) instead of npm? Then it tracks the backend framework — update the backend
+  (see its developer skill) and the bundle refreshes with it. The `tina4` CLI self-updates
+  with `tina4 update`.
+
 ## Backend API Lookups — Use the Live Index
 
 tina4-js talks to a Tina4 backend (Python / PHP / Ruby / Node). When you need a backend route's shape,


### PR DESCRIPTION
Adds a concise **Staying current: check for Tina4 updates** section to the app-developer skill: the AI checks whether the project's installed Tina4 is behind the latest release (framework-specific `outdated`/version check) and surfaces the delta with the upgrade command — **never upgrading silently**. tina4-python also carries the shared **tina4-js** skill's equivalent section (`npm outdated tina4js` + the vendored-bundle note).

Skill docs only. Commands referenced (`tina4 update`, `tina4 doctor`, `composer/npm/gem/pip outdated`) are real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)