### PR TITLE
release: 3.13.67 — MCP database_tables fix (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 Python
 
-Version 3.13.66 — Lightweight Python web framework. See https://tina4.com for full documentation.
+Version 3.13.67 — Lightweight Python web framework. See https://tina4.com for full documentation.
 
 ## Build & Test
 
@@ -786,7 +786,7 @@ uv run tina4python test   # Discovers @tests in src/**/*.py
 - SSE/Streaming via `response.stream()` — Server-Sent Events support for real-time data push. Pass an async generator; framework handles chunked transfer encoding, `text/event-stream` content type, and connection keep-alive
 - MCP server (`tina4_python.mcp`): built-in dev tools auto-start when MCP is a capability of the deployment. Developer API: `McpServer`, `@mcp_tool`, `@mcp_resource`. JSON-RPC 2.0 over SSE. **Security is a two-layer gate (v3.13.40):** `is_enabled()` is a pure capability gate (explicit `TINA4_MCP` wins, else `TINA4_DEBUG`; host-independent), and `is_request_allowed(remote_ip, has_valid_token)` authorises each request on the RAW socket peer (`request.remote_ip`, never X-Forwarded-For): loopback always; a remote caller needs `TINA4_MCP_REMOTE=true` AND a token matching `TINA4_MCP_TOKEN` (fallback `TINA4_API_KEY`; sent as Authorization Bearer / X-MCP-Token / X-Api-Key; no configured token means remote is always denied). All MCP surfaces (REST shim, JSON-RPC, SSE) 404 a disallowed caller. `database_query` is SELECT/WITH-only and rejects stacked statements; the file tools are sandboxed to the project root. `is_localhost()` is informational only, not the gate
 - Tests: 2,901 passing (122 modules)
-- Version: 3.13.66
+- Version: 3.13.67
 
 ## Links
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tina4-python"
-version = "3.13.66"
+version = "3.13.67"
 description = "Tina4 Python v3 — Zero-dependency, lightweight web framework"
 authors = [
     {name = "Andre van Zuydam", email = "andrevanzuydam@gmail.com"}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -523,3 +523,37 @@ class TestMcpEndpointMounted:
         await _api_mcp_endpoint(self._req({"jsonrpc": "2.0", "id": 1, "method": "ping"}), resp)
         _, code, _ = resp.last
         assert code == 404
+
+
+class TestDatabaseTablesTool:
+    """Regression (#164): the database_tables dev-tool must LIST tables.
+
+    Python (master) already calls db.get_tables() correctly — this test locks
+    that contract so a future drift (like the PHP getDatabase() fatal that broke
+    the tool for 3.13.14 -> 3.13.66) is caught. It invokes the real registered
+    handler against a REAL in-memory SQLite database (no mock).
+    """
+
+    def test_lists_real_tables(self):
+        from tina4_python.mcp import McpServer
+        from tina4_python.mcp.tools import register_dev_tools
+        from tina4_python.orm import bind_database
+        from tina4_python.database import Database
+
+        db = Database("sqlite:///:memory:")
+        bind_database(db)                      # the tool resolves via ORM._get_db()
+        db.execute("CREATE TABLE mcp_probe_widget (id INTEGER PRIMARY KEY, name TEXT)")
+
+        server = McpServer("/db-tables", name="DB Tables Test")
+        register_dev_tools(server)
+        resp = json.loads(server.handle_message({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "database_tables", "arguments": {}},
+        }))
+
+        assert "error" not in resp, resp
+        text = resp["result"]["content"][0]["text"]
+        assert "getDatabase" not in text, text
+        tables = json.loads(text)
+        assert isinstance(tables, list), text
+        assert "mcp_probe_widget" in tables, text

--- a/tina4_python/__init__.py
+++ b/tina4_python/__init__.py
@@ -8,7 +8,7 @@ Tina4 Python v3.0 — Zero-dependency, lightweight web framework.
 
 One import, everything works.
 """
-__version__ = "3.13.66"
+__version__ = "3.13.67"
 
 # ── Route decorators ──
 from tina4_python.core.router import (  # noqa: E402, F401


### PR DESCRIPTION
## 3.13.67 — MCP database_tables fix (#164)

Fixes the PHP `database_tables` dev-tool, which called `getDatabase()` (undefined on the base `Database`) and fataled on every call. Now calls `getTables()`, matching Python `get_tables()` / Ruby `tables` / Node `getTables()`.

Cross-checked all four frameworks (feedback_crosscheck_bugs): the bug was PHP-only; Python/Ruby/Node already called the correct method. All four gain a real behavioural lock-in test that INVOKES the `database_tables` handler against a REAL SQLite database (no mock) and asserts a table list — the old tests only checked the tool was registered, which is why a guaranteed fatal shipped 3.13.14 → 3.13.66.

Reported by skorteva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)