### PR TITLE
fix(cli): REPL honours DB credentials + binds the ORM

### DIFF
--- a/tina4_python/cli/__init__.py
+++ b/tina4_python/cli/__init__.py
@@ -311,16 +311,26 @@ def _console(args=None):
 
     # Import everything the user needs
     from tina4_python import get, post, put, patch, delete, Router, Database, ORM, Auth, Queue, Frond
+    from tina4_python.orm import bind_database
     from tina4_python.debug import Log
     from tina4_python.api import Api
     from tina4_python.core.events import on, emit
 
-    # Try to connect database from TINA4_DATABASE_URL
+    # Try to connect database from TINA4_DATABASE_URL. Honour the SEPARATE
+    # credential env vars (TINA4_DATABASE_USERNAME/PASSWORD) — the documented
+    # Tina4 convention keeps credentials out of the URL, so building the handle
+    # from the URL alone left `db` unauthenticated and it failed on every
+    # credentialed engine (PostgreSQL/MySQL/Firebird/MSSQL). Bind it globally
+    # too, so the `db` handle and the ORM models share ONE connected instance
+    # (mirrors ORM._get_db()'s own lazy auto-bind).
     db = None
     db_url = os.environ.get("TINA4_DATABASE_URL")
     if db_url:
         try:
-            db = Database(db_url)
+            username = os.environ.get("TINA4_DATABASE_USERNAME", "")
+            password = os.environ.get("TINA4_DATABASE_PASSWORD", "")
+            db = Database(db_url, username, password)
+            bind_database(db)
             print(f"  Database: {db_url}")
         except Exception as e:
             print(f"  Database: failed ({e})")


### PR DESCRIPTION
`tina4 console` built its `db` handle from `TINA4_DATABASE_URL` alone, dropping the separate `TINA4_DATABASE_USERNAME`/`TINA4_DATABASE_PASSWORD` env vars (the documented Tina4 convention keeps credentials out of the URL). So on every credentialed engine (PostgreSQL/MySQL/Firebird/MSSQL) the REPL's `db` failed with "no password supplied", while ORM models still worked (they lazy-bind with creds) — a confusing split. It also never called `bind_database(db)`.

**Fix:** read the credentials too and `bind_database(db)`, so the `db` handle and the ORM models share ONE connected instance (mirrors `ORM._get_db()`'s own lazy auto-bind).

**Verified live** vs real PostgreSQL: OLD `Database(url)` → `fe_sendauth: no password supplied`; NEW `Database(url,user,pass)` + bind → connects `{ok:1}`. SQLite smoke confirms the handle + `bind_database`→ORM mechanics. Full pytest suite: 3432 passed / 108 skipped / 0 failures.

Cross-framework: Ruby (`initialize!`→`Database.new` reads ENV creds) and Node (`initDatabase({url})` merges env creds + auto-binds) already route through the credential-aware bootstrap, so they were **not** affected. PHP had the same class of bug (plus a legacy-env-var-name mistake) — fixed in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)