### PR TITLE
cli: point new projects to the dev-admin AI coder after init

### DIFF
--- a/tina4_python/cli/__init__.py
+++ b/tina4_python/cli/__init__.py
@@ -787,6 +787,8 @@ def _init(args):
     print(f"\nProject scaffolded at {target.resolve()}")
     print("  Run: tina4python serve")
     print("  Run: tina4python ai        (detect & install AI tool context)")
+    print("  Then: open the dev admin at /__dev, paste your Tina4 MCP key,")
+    print("        and describe what to build. See https://tina4.com/build-with-ai")
 
 
 # ── Serve ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
After `tina4python init`, the post-init output now points the user to the next step: open the dev admin at `/__dev`, paste the Tina4 MCP key, and describe what to build. Links to https://tina4.com/build-with-ai for the full walkthrough.

Two printed lines only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)