### PR TITLE
docs: add Codex skill entrypoints

### DIFF
--- a/.agents/skills/tina4-developer-python/SKILL.md
+++ b/.agents/skills/tina4-developer-python/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: tina4-developer-python
+description: Tina4 Python application-development instructions.
+---
+
+# Tina4 Python Developer
+
+Read and follow the canonical tracked skill at `../../../.claude/skills/tina4-developer-python/SKILL.md`.

--- a/.agents/skills/tina4-js/SKILL.md
+++ b/.agents/skills/tina4-js/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: tina4-js
+description: Tina4-js frontend instructions for Tina4 projects.
+---
+
+# Tina4-js
+
+Read and follow the canonical tracked skill at `../../../.claude/skills/tina4-js/SKILL.md`.

--- a/.agents/skills/tina4-maintainer/SKILL.md
+++ b/.agents/skills/tina4-maintainer/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: tina4-maintainer
+description: Tina4 cross-language maintenance instructions.
+---
+
+# Tina4 Maintainer
+
+Read and follow the canonical tracked skill at `../../../.claude/skills/tina4-maintainer/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 v3.13.87. 98 built-in features, zero dependencies. Python 3.12+.
 
+## AI Skills
+
+Codex discovers the project skills in `.agents/skills`; each is a tracked entrypoint to the canonical `.claude/skills` instructions also used by Claude. Use the maintainer, Python developer, and Tina4-js skills that apply to the task.
+
 ## Framework
 
 This project uses Tina4 Python. All features are built in — do not install external packages for routing, ORM, auth, templates, GraphQL, WebSocket, email, queues, or any other feature listed below.


### PR DESCRIPTION
Expose the existing tracked Claude skills through Codex-native .agents/skills entrypoints without duplicating content.