### PR TITLE
Release 3.13.100

### DIFF
--- a/.claude/skills/tina4-js/SKILL.md
+++ b/.claude/skills/tina4-js/SKILL.md
@@ -2,7 +2,7 @@
 name: tina4-js
 description: >
   Use whenever working with tina4-js — the lightweight reactive frontend framework.
-  Trigger on any mention of tina4-js, tina4 signals, persistent signals, persist(),
+  Trigger on any mention of tina4-js, tina4js, Tina4 JS, tina4 signals, persistent signals, persist(),
   Tina4Element, tina4 html tagged templates, tina4 routing, tina4 WebSocket client,
   tina4 API client, or persistent storage of UI preferences. Also trigger when the user
   is building a client-rendered frontend for a Tina4 backend, or when they're working

--- a/.claude/skills/tina4-js/references/html-and-components.md
+++ b/.claude/skills/tina4-js/references/html-and-components.md
@@ -33,6 +33,9 @@ Returns a `DocumentFragment` with real DOM nodes. Templates are cached by string
 | `null`/`undefined` | Empty |
 | `false` | The text "false" (NOT empty!) |
 
+Valid HTML comments are ignored when determining interpolation context. Quotes inside a comment
+do not turn a following content interpolation into an attribute binding.
+
 **Critical:** `${false}` renders as the literal text "false". For conditional show/hide, use:
 ```ts
 ${() => condition ? html`<p>Show</p>` : null}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ inherit the extension.
 - Preserve nested root blocks through a depth-aware final substitution pass.
 - Bound template, fragment, and expression caches, with TTL sweeps for stale entries.
 - Retry transient AI skill-download failures.
+- Activate the tina4-js skill for `tina4js` and `Tina4 JS` spellings as well as `tina4-js`.
 - Keep `pyproject.toml`, `uv.lock`, the packaged fallback, and the AI-facing guide on one version.
 
 ## 3.13.99

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@ number means the same thing everywhere.
 **The authoritative release notes for every shipped version live in the documentation:**
 https://tina4.com/python/36-releases
 
-This file is deliberately NOT a copy of those notes. Duplicating them is exactly how a
-changelog rots into claiming a version that was never cut, so this file records only
-UNRELEASED work. When a version ships, its notes go to the release notes above.
+This file records framework-specific changes. The release notes above remain the
+authority for shipped versions.
+
+## 3.13.100 (unreleased)
+
+- Reject a second `{% extends %}` tag instead of replacing the first parent without warning.
+- Preserve nested root blocks through a depth-aware final substitution pass.
+- Bound template, fragment, and expression caches, with TTL sweeps for stale entries.
+- Retry transient AI skill-download failures.
+- Keep `pyproject.toml`, `uv.lock`, the packaged fallback, and the AI-facing guide on one version.
+
+## 3.13.99
 
 ### Breaking: `request.params` is route-params-only
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ authority for shipped versions.
 
 ## 3.13.100 (unreleased)
 
+### Breaking: Frond instance extensions stay local
+
+Calling `add_filter`, `add_global`, or `add_test` on a Frond instance now changes
+that renderer only. Register on `Frond` itself when every later instance must
+inherit the extension.
+
 - Reject a second `{% extends %}` tag instead of replacing the first parent without warning.
 - Preserve nested root blocks through a depth-aware final substitution pass.
 - Bound template, fragment, and expression caches, with TTL sweeps for stale entries.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 Python
 
-Version 3.13.99 - Lightweight Python web framework. See https://tina4.com for full documentation.
+Version 3.13.100 - Lightweight Python web framework. See https://tina4.com for full documentation.
 
 ## Build & Test
 
@@ -857,7 +857,7 @@ uv run tina4python test   # Discovers @tests in src/**/*.py
 - SSE/Streaming via `response.stream()` — Server-Sent Events support for real-time data push. Pass an async generator; framework handles chunked transfer encoding, `text/event-stream` content type, and connection keep-alive
 - MCP server (`tina4_python.mcp`): built-in dev tools auto-start when MCP is a capability of the deployment. Developer API: `McpServer`, `@mcp_tool`, `@mcp_resource`. JSON-RPC 2.0 over SSE. **Security is a two-layer gate (v3.13.40):** `is_enabled()` is a pure capability gate (explicit `TINA4_MCP` wins, else `TINA4_DEBUG`; host-independent), and `is_request_allowed(remote_ip, has_valid_token)` authorises each request on the RAW socket peer (`request.remote_ip`, never X-Forwarded-For): loopback always; a remote caller needs `TINA4_MCP_REMOTE=true` AND a token matching `TINA4_MCP_TOKEN` (fallback `TINA4_API_KEY`; sent as Authorization Bearer / X-MCP-Token / X-Api-Key; no configured token means remote is always denied). All MCP surfaces (REST shim, JSON-RPC, SSE) 404 a disallowed caller. `database_query` is SELECT/WITH-only and rejects stacked statements; the file tools are sandboxed to the project root. `is_localhost()` is informational only, not the gate
 - Tests: 5,063 passing, 0 failures, **0 skipped** — measured 2026-08-06 on the lab (Ubuntu 24.04.4 LTS x86_64, Python 3.13.3, live services, `TINA4_REQUIRE_SERVICES=1`, 456s, run as root). **Firebird is NOT excluded.** The lab provisions a live Firebird 5 (`firebirdsql/firebird:5` on :3050, `TINA4_TEST_FIREBIRD_URL`) and those tests run. What IS deliberate is Firebird's absence from the `TINA4_REQUIRE_SERVICES` keyword gate in `tests/conftest.py`: GitHub CI does not provision Firebird, so a Firebird skip has to stay green *there*. Those are two different things and this line used to conflate them into "excluded by design", which read as "the Firebird tests do not run" — they do. **Nothing skips any more.** The last skip was `tests/test_session_backend_failure.py` `[needs:no-dac-override]`: the suite runs as root, root holds `CAP_DAC_OVERRIDE`, so a write went straight through a 0400 file and no real `EACCES` was reachable — and as root the second `save()` returned `True`, so that skip was hiding a FAILING assertion, not merely an unrunnable one. The test now stops being root for the length of the failing write (`os.seteuid` to `nobody`; the saved uid stays 0, so a `finally` always restores it) and the kernel raises the genuine errno-13 the test asserts. Two parts of that are load-bearing: the log directory is handed to the same uid, because dropping the uid otherwise denies `Log.error` as well and the EACCES under test goes unrecorded (`_LogWriter.write` swallows `OSError` unless `TINA4_LOG_STRICT`); and the fixture root is its own 0755 `mkdtemp` rather than `tmp_path`, whose 0700 root-owned parents make every denial a directory traversal, which would pass for the wrong reason. Re-measure with `.venv/bin/python -m pytest tests/ -q` and quote the summary line, never the exit code
-- Version: 3.13.99
+- Version: 3.13.100
 
 ## Links
 

--- a/plan/frond-instance-registration-scope.md
+++ b/plan/frond-instance-registration-scope.md
@@ -1,0 +1,26 @@
+# Task: Frond instance registration scope
+
+**Outcome:** Frond class registrations remain process-global while instance registrations remain local, per ADR-0052.
+
+## Scope
+- [x] Read Feature 56 and ADR-0052
+- [x] Add failing scope regressions
+- [x] Remove instance-to-class writes
+- [ ] Verify focused and full lab suites
+
+## Parity
+| Feature | Python | PHP | Ruby | Node.js |
+|---|---|---|---|---|
+| ADR-0052 scope | in progress | in progress | in progress | in progress |
+
+## Tests
+- [x] Class registration reaches later instances
+- [x] Instance filter/global/test registrations do not reach later instances
+
+## Bugs
+- [ ] EX-INSTANCE-LEAKS-CLASS
+
+## Commits
+- pending
+
+## Status: In Progress

--- a/plan/frond-instance-registration-scope.md
+++ b/plan/frond-instance-registration-scope.md
@@ -6,21 +6,21 @@
 - [x] Read Feature 56 and ADR-0052
 - [x] Add failing scope regressions
 - [x] Remove instance-to-class writes
-- [ ] Verify focused and full lab suites
+- [x] Verify focused and full lab suites
 
 ## Parity
 | Feature | Python | PHP | Ruby | Node.js |
 |---|---|---|---|---|
-| ADR-0052 scope | in progress | in progress | in progress | in progress |
+| ADR-0052 scope | ✅ | ✅ | ✅ | ✅ |
 
 ## Tests
 - [x] Class registration reaches later instances
 - [x] Instance filter/global/test registrations do not reach later instances
 
 ## Bugs
-- [ ] EX-INSTANCE-LEAKS-CLASS
+- [x] EX-INSTANCE-LEAKS-CLASS
 
 ## Commits
-- pending
+- `ecf66e6` - implementation, regressions, CHANGELOG
 
-## Status: In Progress
+## Status: Complete

--- a/plan/release-version-consistency.md
+++ b/plan/release-version-consistency.md
@@ -1,0 +1,34 @@
+# Python 3.13.100 version consistency
+
+## Outcome
+
+Every Python package version source reports `3.13.100`.
+
+## Scope
+
+- [x] Compare `pyproject.toml`, `uv.lock`, and the packaged fallback literal.
+- [x] Prove the existing consistency regression fails.
+- [x] Update the lockfile and fallback literal.
+- [x] Re-run the focused regression.
+
+## Parity
+
+| Version source | Status |
+|---|---|
+| `pyproject.toml` | ✅ `3.13.100` |
+| `uv.lock` | ✅ `3.13.100` |
+| packaged fallback | ✅ `3.13.100` |
+
+## Tests
+
+- [x] `uv run pytest -q tests/test_version_constant.py`
+
+## Bugs
+
+- [x] The release bump left the packaged fallback at `3.13.99`.
+
+## Commits
+
+- This change: complete the Python `3.13.100` version bump.
+
+## Status: Complete

--- a/plan/release-version-consistency.md
+++ b/plan/release-version-consistency.md
@@ -2,13 +2,14 @@
 
 ## Outcome
 
-Every Python package version source reports `3.13.100`.
+Every Python package and AI-facing version source reports `3.13.100`.
 
 ## Scope
 
 - [x] Compare `pyproject.toml`, `uv.lock`, and the packaged fallback literal.
 - [x] Prove the existing consistency regression fails.
 - [x] Update the lockfile and fallback literal.
+- [x] Update the current-version markers in the AI-facing guide.
 - [x] Re-run the focused regression.
 
 ## Parity
@@ -18,10 +19,12 @@ Every Python package version source reports `3.13.100`.
 | `pyproject.toml` | ✅ `3.13.100` |
 | `uv.lock` | ✅ `3.13.100` |
 | packaged fallback | ✅ `3.13.100` |
+| AI-facing guide | ✅ `3.13.100` |
 
 ## Tests
 
 - [x] `uv run pytest -q tests/test_version_constant.py`
+- [x] Version consistency + fallback regressions: 5 passed, 0 failed.
 
 ## Bugs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tina4-python"
-version = "3.13.99"
+version = "3.13.100"
 description = "Tina4 Python v3 — Zero-dependency, lightweight web framework"
 authors = [
     {name = "Andre van Zuydam", email = "andrevanzuydam@gmail.com"}

--- a/tests/test_ai_fetch_retry.py
+++ b/tests/test_ai_fetch_retry.py
@@ -1,0 +1,88 @@
+"""`install_skills()`'s GitHub fetch (`tina4_python.ai._fetch_bytes`) must survive
+raw.githubusercontent.com's intermittent 503-under-load — a freshly cut release
+tag is "cold" on GitHub's CDN until it warms, and one `tina4 ai` install makes
+~30 fetches, so a single transient blip must not abort the whole install.
+
+Real local HTTP server (stdlib http.server on a real socket), no mocks, no
+monkeypatched urllib/time — proves the retry loop actually rides through
+retryable statuses, and that a permanent 404 is NOT retried (fails fast)."""
+import http.server
+import threading
+import time
+
+from tina4_python.ai import _fetch_bytes
+
+
+class _SequenceServer:
+    """Serves a scripted SEQUENCE of (status, body) per path, advancing one
+    step on every hit to that path. Lets us drive the real retry loop
+    (503, 503, 200) against a real socket — no mock, no monkeypatched
+    urllib, and no patched time.sleep."""
+
+    def __init__(self, sequences):
+        # sequences: path -> list of (status, body_bytes)
+        self.sequences = {p: list(seq) for p, seq in sequences.items()}
+        self.hits = {p: 0 for p in sequences}
+        seqs = self.sequences
+        hits = self.hits
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *a):  # silence the test server
+                pass
+
+            def do_GET(self):
+                path = self.path.split("?", 1)[0]
+                seq = seqs.get(path, [(200, b"ok")])
+                idx = min(hits.get(path, 0), len(seq) - 1)
+                hits[path] = hits.get(path, 0) + 1
+                status, payload = seq[idx]
+                self.send_response(status)
+                self.send_header("Content-Type", "application/octet-stream")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                if payload:
+                    self.wfile.write(payload)
+
+        self._httpd = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self._httpd.server_address[1]
+        self.base_url = f"http://127.0.0.1:{self.port}"
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+
+    def count(self, path):
+        return self.hits.get(path, 0)
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+
+
+def test_fetch_retries_transient_503_then_returns_body():
+    """POSITIVE: two transient 503s, then a 200 — _fetch_bytes must ride
+    through both and hand back the real body (not None)."""
+    with _SequenceServer({"/skill": [(503, b"down"), (503, b"down"),
+                                      (200, b"skill body")]}) as s:
+        data = _fetch_bytes(f"{s.base_url}/skill")
+        assert data == b"skill body"
+        assert s.count("/skill") == 3  # proves it actually retried twice, not just once
+
+
+def test_fetch_fast_fails_persistent_404_without_retrying():
+    """NEGATIVE: a permanent 404 must return None on the FIRST attempt — no
+    retry, no backoff sleep. If the loop wrongly retried a 404 this would
+    take 2 + 4 + 6 + 8 = 20s+ (and hit the server 5 times instead of 1); the
+    elapsed-time bound is what makes this a "fails fast" assertion rather
+    than just a status check."""
+    with _SequenceServer({"/missing": [(404, b"not found")]}) as s:
+        start = time.monotonic()
+        data = _fetch_bytes(f"{s.base_url}/missing")
+        elapsed = time.monotonic() - start
+
+        assert data is None
+        assert s.count("/missing") == 1  # NEGATIVE: no retry on a permanent 404
+        assert elapsed < 2.0  # fast — well under even a single 2s backoff sleep

--- a/tests/test_frond.py
+++ b/tests/test_frond.py
@@ -506,6 +506,42 @@ class TestSetIncludeExtends:
         assert "<h1>My Page</h1>" in result
         assert "<div>Hello</div>" in result
 
+    def test_extends_single_still_works(self, engine, tpl_dir):
+        """Positive lock-in: one {% extends %} tag renders exactly as before."""
+        (tpl_dir / "base.html").write_text("<h1>{% block title %}Default{% endblock %}</h1>")
+        (tpl_dir / "page.html").write_text('{% extends "base.html" %}{% block title %}Solo{% endblock %}')
+        result = engine.render("page.html", {})
+        assert result == "<h1>Solo</h1>"
+
+    def test_extends_twice_raises(self, engine, tpl_dir):
+        """3.13.100: a SECOND {% extends %} tag raises instead of being
+        silently discarded.
+
+        Before the fix, only the first (leading) {% extends %} was ever
+        matched by the source-level regex; the second tag -- along with the
+        rest of the child's non-block content -- was silently dropped the
+        same way ordinary child content outside a block always is. The
+        author's second extends target was invisible with no error, which is
+        confusing and almost always a mistake. Mirrors the unknown-tag-raises
+        policy (3.13.89): fail loud instead of guessing.
+        """
+        (tpl_dir / "base_a.html").write_text("A {% block content %}{% endblock %}")
+        (tpl_dir / "base_b.html").write_text("B {% block content %}{% endblock %}")
+        (tpl_dir / "double.html").write_text(
+            '{% extends "base_a.html" %}\n'
+            '{% extends "base_b.html" %}\n'
+            '{% block content %}X{% endblock %}'
+        )
+        with pytest.raises(ValueError, match=r'2 "\{% extends %\}" tags'):
+            engine.render("double.html", {})
+
+    def test_extends_twice_raises_via_render_string(self, engine, tpl_dir):
+        """The same double-extends guard applies on the render_string() path."""
+        (tpl_dir / "base_a.html").write_text("A")
+        (tpl_dir / "base_b.html").write_text("B")
+        with pytest.raises(ValueError, match=r'2 "\{% extends %\}" tags'):
+            engine.render_string('{% extends "base_a.html" %}{% extends "base_b.html" %}', {})
+
     def test_extends_default_block(self, engine, tpl_dir):
         (tpl_dir / "base.html").write_text("{% block title %}Default Title{% endblock %}")
         (tpl_dir / "page.html").write_text('{% extends "base.html" %}')

--- a/tests/test_frond.py
+++ b/tests/test_frond.py
@@ -633,6 +633,52 @@ class TestSetIncludeExtends:
         assert "<section>" in result
         assert "LEAF" in result
 
+    def test_root_nested_block_survives_final_substitution(self, engine, tpl_dir):
+        """Regression (3.13.100): a {% block %} the ROOT template nests INSIDE
+        another {% block %} used to vanish, wrapper and all.
+
+        The final block-substitution pass against the resolved root source
+        used a non-depth-aware regex (_BLOCK_RE), so the OUTER block's open
+        tag paired with the FIRST {% endblock %} -- the NESTED block's own
+        close tag -- truncating the outer block's captured content and
+        dropping everything after the inner endblock. Before the fix this
+        rendered "<section></section>" (both the wrapper's own placement
+        AND the leaf's override lost); the wrapper only survived here
+        because it happens to sit before the truncation point, not because
+        it was handled correctly. Mutation check: reverting
+        _substitute_blocks to a flat `_BLOCK_RE.sub` reproduces exactly
+        that "<section></section>".
+        """
+        (tpl_dir / "root.html").write_text(
+            '{% block body %}<section>{% block inner %}{% endblock %}</section>{% endblock %}'
+        )
+        (tpl_dir / "mid.html").write_text(
+            '{% extends "root.html" %}{% block inner %}MID{% endblock %}'
+        )
+        (tpl_dir / "leaf.html").write_text(
+            '{% extends "mid.html" %}{% block inner %}LEAF{% endblock %}'
+        )
+        result = engine.render("leaf.html", {})
+        assert result == "<section>LEAF</section>"
+
+    def test_root_nested_block_intermediate_override_survives(self, engine, tpl_dir):
+        """3-level chain where the ROOT nests blocks AND an INTERMEDIATE
+        template overrides the nested block without the leaf touching it
+        again -- the full structure (root's wrapper + mid's override) must
+        reach the final render untouched by the leaf.
+        """
+        (tpl_dir / "root.html").write_text(
+            '{% block body %}<section>{% block inner %}{% endblock %}</section>{% endblock %}'
+        )
+        (tpl_dir / "mid.html").write_text(
+            '{% extends "root.html" %}{% block inner %}MID{% endblock %}'
+        )
+        (tpl_dir / "leaf.html").write_text(
+            '{% extends "mid.html" %}{% block unrelated %}unused{% endblock %}'
+        )
+        result = engine.render("leaf.html", {})
+        assert result == "<section>MID</section>"
+
     def test_two_level_extends_default_block(self, engine, tpl_dir):
         """Child defines a block, grandchild doesn't override it — default should show."""
         (tpl_dir / "base.html").write_text(

--- a/tests/test_frond_cache_bounds.py
+++ b/tests/test_frond_cache_bounds.py
@@ -1,0 +1,243 @@
+# Lock-in tests for 3.13.100's Frond cache bounds (ADR-0004).
+#
+# Before this fix, Python was the outlier: PHP/Ruby/Node already capped their
+# TEMPLATE caches at TEMPLATE_CACHE_MAX (256), but Python's `_compiled`,
+# `_compiled_strings` and `_compiled_fn` were plain unbounded dicts. And in
+# ALL FOUR frameworks the `{% cache %}` fragment store (`_fragment_cache`) was
+# both unbounded AND never swept a TTL-expired entry: a key that expired and
+# was never read again sat in memory for the life of the worker. This file
+# also locks in `_filter_chain_cache`, a per-expression memo that turned out
+# to still be a plain unbounded instance dict despite being the direct
+# Python counterpart of Ruby's `@filter_chain_cache` / Node's
+# `filterChainCache` (both capped) -- the four already-`@lru_cache`d module
+# functions (`_split_dotted`, `_has_low_precedence_op`, `_expr_descriptor`,
+# `_split_on_pipe`) are pure functions and don't cover it, since it's an
+# INSTANCE dict on a bound method.
+#
+# Reproduced for real below: real renders through the real engine, real
+# template files on disk, and the real instance caches read directly. No
+# mocks: nothing here stands in for the engine, the clock, or the filesystem.
+import time
+
+import pytest
+
+from tina4_python.frond import Frond
+from tina4_python.frond.engine import TEMPLATE_CACHE_MAX, MEMO_CACHE_MAX
+
+
+@pytest.fixture
+def engine(tmp_path):
+    Frond.clear_registry()
+    return Frond(template_dir=str(tmp_path))
+
+
+@pytest.fixture
+def tpl_dir(tmp_path):
+    return tmp_path
+
+
+class TestCacheCapConstants:
+    def test_template_cache_max_is_a_positive_cap(self):
+        assert TEMPLATE_CACHE_MAX > 0
+
+    def test_memo_cache_max_is_a_positive_cap_not_smaller_than_template_cap(self):
+        assert MEMO_CACHE_MAX > 0
+        assert MEMO_CACHE_MAX >= TEMPLATE_CACHE_MAX
+
+
+class TestTemplateCacheBound:
+    """`_compiled` / `_compiled_strings` / `_compiled_fn` were unbounded."""
+
+    def test_compiled_strings_and_compiled_fn_do_not_grow_without_limit(self, engine):
+        distinct = TEMPLATE_CACHE_MAX * 2 + 13
+
+        for index in range(distinct):
+            rendered = engine.render_string(f"t{index}={{{{ n + {index} }}}}", {"n": 10})
+            assert rendered == f"t{index}={10 + index}"
+
+        strings_size = len(engine._compiled_strings)
+        assert strings_size <= TEMPLATE_CACHE_MAX, (
+            f"_compiled_strings grew to {strings_size} entries for {distinct} distinct "
+            f"sources; cap is {TEMPLATE_CACHE_MAX}"
+        )
+
+        fn_size = len(engine._compiled_fn)
+        assert fn_size <= TEMPLATE_CACHE_MAX, (
+            f"_compiled_fn grew to {fn_size} entries for {distinct} distinct sources; "
+            f"cap is {TEMPLATE_CACHE_MAX}"
+        )
+
+    def test_evicted_string_template_recompiles_and_stays_correct(self, engine):
+        first_source = "first={{ n + 1 }}"
+        assert engine.render_string(first_source, {"n": 10}) == "first=11"
+
+        for index in range(TEMPLATE_CACHE_MAX * 2):
+            engine.render_string(f"filler{index}={{{{ n }}}}", {"n": index})
+
+        import hashlib
+        first_key = hashlib.md5(first_source.encode()).hexdigest()
+        assert first_key not in engine._compiled_strings, "the first entry should have been evicted"
+
+        # Re-tokenizes from cold, still byte-correct, still tracks the data.
+        assert engine.render_string(first_source, {"n": 10}) == "first=11"
+        assert engine.render_string(first_source, {"n": 100}) == "first=101"
+
+    def test_file_template_cache_is_bounded(self, engine, tpl_dir):
+        distinct = TEMPLATE_CACHE_MAX + 41
+
+        for index in range(distinct):
+            (tpl_dir / f"tpl{index}.twig").write_text(f"T{index}={{{{ n + {index} }}}}", encoding="utf-8")
+
+        for index in range(distinct):
+            assert engine.render(f"tpl{index}.twig", {"n": 5}) == f"T{index}={5 + index}"
+
+        compiled_size = len(engine._compiled)
+        assert compiled_size <= TEMPLATE_CACHE_MAX, (
+            f"_compiled grew to {compiled_size} entries for {distinct} distinct templates; "
+            f"cap is {TEMPLATE_CACHE_MAX}"
+        )
+
+        # Every template still renders correctly after the sweep, including
+        # the earliest ones, which were evicted and must re-read from disk.
+        for index in range(distinct):
+            assert engine.render(f"tpl{index}.twig", {"n": 7}) == f"T{index}={7 + index}"
+
+    def test_cache_below_the_cap_is_not_evicted(self, engine):
+        below_cap = TEMPLATE_CACHE_MAX - 1
+        for index in range(below_cap):
+            engine.render_string(f"u{index}={{{{ n }}}}", {"n": index})
+
+        assert len(engine._compiled_strings) == below_cap
+
+    def test_clear_cache_still_empties_every_template_cache(self, engine, tpl_dir):
+        (tpl_dir / "page.twig").write_text("page={{ n }}", encoding="utf-8")
+        assert engine.render("page.twig", {"n": 3}) == "page=3"
+        assert engine.render_string("str={{ n }}", {"n": 4}) == "str=4"
+
+        assert engine._compiled
+        assert engine._compiled_strings
+        assert engine._compiled_fn
+
+        engine.clear_cache()
+
+        assert engine._compiled == {}
+        assert engine._compiled_strings == {}
+        assert engine._compiled_fn == {}
+
+        # Still renders correctly from cold after a clear.
+        assert engine.render("page.twig", {"n": 3}) == "page=3"
+        assert engine.render_string("str={{ n }}", {"n": 4}) == "str=4"
+
+    def test_inheritance_survives_an_eviction_storm(self, engine, tpl_dir):
+        (tpl_dir / "base.twig").write_text(
+            "BASE[{% block body %}dflt{% endblock %}]", encoding="utf-8"
+        )
+        (tpl_dir / "child.twig").write_text(
+            '{% extends "base.twig" %}{% block body %}{{ n * 2 }}{% endblock %}', encoding="utf-8"
+        )
+
+        assert engine.render("child.twig", {"n": 4}) == "BASE[8]"
+
+        for index in range(TEMPLATE_CACHE_MAX * 2):
+            engine.render_string(f"storm{index}={{{{ n }}}}", {"n": index})
+
+        assert engine.render("child.twig", {"n": 4}) == "BASE[8]"
+        assert engine.render("child.twig", {"n": 10}) == "BASE[20]"
+
+
+class TestFilterChainCacheBound:
+    """`_filter_chain_cache` was a plain unbounded instance dict."""
+
+    def test_does_not_grow_without_limit_for_distinct_filter_expressions(self, engine):
+        distinct = MEMO_CACHE_MAX * 2 + 17
+
+        for index in range(distinct):
+            result = engine.render_string(f"{{{{ n | default({index}) }}}}", {})
+            assert result == str(index)
+
+        size = len(engine._filter_chain_cache)
+        assert size <= MEMO_CACHE_MAX, (
+            f"_filter_chain_cache grew to {size} entries for {distinct} distinct "
+            f"expressions; cap is {MEMO_CACHE_MAX}"
+        )
+
+    def test_evicts_nothing_while_under_the_cap(self, engine):
+        below_cap = MEMO_CACHE_MAX - 1
+        for index in range(below_cap):
+            engine.render_string(f"{{{{ n | default({index}) }}}}", {})
+
+        assert len(engine._filter_chain_cache) == below_cap
+
+    def test_clear_cache_empties_it(self, engine):
+        engine.render_string("{{ n | default(1) }}", {})
+        assert engine._filter_chain_cache
+
+        engine.clear_cache()
+        assert engine._filter_chain_cache == {}
+        assert engine.render_string("{{ n | default(1) }}", {}) == "1"
+
+
+class TestFragmentCacheBoundAndSweep:
+    """`_fragment_cache` was unbounded AND a TTL-expired entry was never swept."""
+
+    def test_does_not_grow_without_limit_for_many_distinct_cache_keys(self, engine):
+        distinct = TEMPLATE_CACHE_MAX * 2 + 13
+
+        for index in range(distinct):
+            result = engine.render_string(
+                f'{{% cache "frag{index}" 300 %}}{{{{ n }}}}{{% endcache %}}', {"n": index}
+            )
+            assert result == str(index)
+
+        size = len(engine._fragment_cache)
+        assert size <= TEMPLATE_CACHE_MAX, (
+            f"_fragment_cache grew to {size} entries for {distinct} distinct keys; "
+            f"cap is {TEMPLATE_CACHE_MAX}"
+        )
+
+    def test_evicts_nothing_while_under_the_cap(self, engine):
+        below_cap = TEMPLATE_CACHE_MAX - 1
+        for index in range(below_cap):
+            engine.render_string(
+                f'{{% cache "under{index}" 300 %}}{{{{ n }}}}{{% endcache %}}', {"n": index}
+            )
+
+        assert len(engine._fragment_cache) == below_cap
+
+    def test_recomputes_a_fragment_evicted_by_the_size_cap_and_stays_correct(self, engine):
+        first = engine.render_string('{% cache "first_evictable" 300 %}{{ n }}{% endcache %}', {"n": "one"})
+        assert first == "one"
+
+        for index in range(TEMPLATE_CACHE_MAX * 2):
+            engine.render_string(
+                f'{{% cache "filler{index}" 300 %}}{{{{ n }}}}{{% endcache %}}', {"n": index}
+            )
+
+        assert "first_evictable" not in engine._fragment_cache, (
+            "the first fragment should have been evicted by the size cap"
+        )
+
+        # Recomputes from cold with fresh data -- never reads stale content.
+        recomputed = engine.render_string('{% cache "first_evictable" 300 %}{{ n }}{% endcache %}', {"n": "two"})
+        assert recomputed == "two"
+
+    def test_sweeps_a_ttl_expired_fragment_instead_of_leaving_it_stale_forever(self, engine):
+        short_lived = engine.render_string('{% cache "short_lived" 1 %}{{ n }}{% endcache %}', {"n": "first"})
+        assert short_lived == "first"
+        engine.render_string('{% cache "control" 300 %}{{ n }}{% endcache %}', {"n": "control"})
+
+        time.sleep(1.1)
+
+        # Touch a DIFFERENT cache key -- proving the sweep runs as a side
+        # effect of any fragment-cache render, not only on a re-read of the
+        # SAME key (which the old code already handled by silent overwrite).
+        engine.render_string('{% cache "trigger" 300 %}{{ n }}{% endcache %}', {"n": "trigger"})
+
+        assert "short_lived" not in engine._fragment_cache, (
+            "the expired entry should have been swept, not merely left stale"
+        )
+        assert "control" in engine._fragment_cache, "a still-live entry must not be swept early"
+
+        # A fresh render recomputes rather than ever reading stale content.
+        refreshed = engine.render_string('{% cache "short_lived" 1 %}{{ n }}{% endcache %}', {"n": "second"})
+        assert refreshed == "second"

--- a/tests/test_parity_group_c.py
+++ b/tests/test_parity_group_c.py
@@ -97,6 +97,12 @@ def _isolate_frond_registry():
 
 
 class TestFrondClassmethodProxies:
+    def test_class_registration_is_process_global(self):
+        from tina4_python.frond import Frond
+
+        Frond.add_filter("class_filter", lambda value: f"class:{value}")
+        assert Frond()._filters["class_filter"]("value") == "class:value"
+
     def test_add_filter_callable_on_class(self):
         from tina4_python.frond import Frond
 
@@ -106,18 +112,16 @@ class TestFrondClassmethodProxies:
         assert "upper_x" in engine._filters
         assert engine._filters["upper_x"]("hi") == "HI"
 
-    def test_add_filter_callable_on_instance(self):
+    def test_instance_filter_registration_is_instance_local(self):
         from tina4_python.frond import Frond
 
         engine = Frond()
         engine.add_filter("instance_x", lambda v: f"[{v}]")
         # Instance has it
         assert engine._filters["instance_x"]("y") == "[y]"
-        # Class-level registry also got it
-        assert "instance_x" in Frond._class_filters
-        # And NEW instances pick it up
+        assert "instance_x" not in Frond._class_filters
         engine_2 = Frond()
-        assert "instance_x" in engine_2._filters
+        assert "instance_x" not in engine_2._filters
 
     def test_add_global_callable_on_class(self):
         from tina4_python.frond import Frond
@@ -126,13 +130,14 @@ class TestFrondClassmethodProxies:
         engine = Frond()
         assert engine._globals["APP_NAME"] == "ParityApp"
 
-    def test_add_global_callable_on_instance(self):
+    def test_instance_global_registration_is_instance_local(self):
         from tina4_python.frond import Frond
 
         engine = Frond()
         engine.add_global("INST_GLOBAL", 42)
         assert engine._globals["INST_GLOBAL"] == 42
-        assert Frond._class_globals["INST_GLOBAL"] == 42
+        assert "INST_GLOBAL" not in Frond._class_globals
+        assert "INST_GLOBAL" not in Frond()._globals
 
     def test_add_test_callable_on_class(self):
         from tina4_python.frond import Frond
@@ -142,12 +147,14 @@ class TestFrondClassmethodProxies:
         assert engine._tests["positive"](5) is True
         assert engine._tests["positive"](-1) is False
 
-    def test_add_test_callable_on_instance(self):
+    def test_instance_test_registration_is_instance_local(self):
         from tina4_python.frond import Frond
 
         engine = Frond()
         engine.add_test("starts_with_a", lambda s: s.startswith("a"))
         assert "starts_with_a" in engine._tests
+        assert "starts_with_a" not in Frond._class_tests
+        assert "starts_with_a" not in Frond()._tests
 
 
 # ─── @GraphQL.resolve decorator ───────────────────────────────────────────

--- a/tina4_python/__init__.py
+++ b/tina4_python/__init__.py
@@ -51,7 +51,7 @@ def _resolve_version() -> str:
     #
     # test_version_constant.py now asserts this literal equals the pyproject
     # version, so the release bump cannot leave it behind again.
-    return "3.13.99"
+    return "3.13.100"
 
 
 __version__ = _resolve_version()

--- a/tina4_python/ai/__init__.py
+++ b/tina4_python/ai/__init__.py
@@ -67,14 +67,29 @@ def _skills_ref() -> str:
         return "main"
 
 
-def _fetch_bytes(url: str) -> "bytes | None":
+def _fetch_bytes(url: str, attempts: int = 5) -> "bytes | None":
+    # raw.githubusercontent.com returns an intermittent 503 under load (a freshly
+    # cut tag is "cold" until GitHub warms its CDN), so a single failed fetch out of
+    # the ~30 an install makes should not abort it. Retry a transient status
+    # (429 / 5xx) and connection errors; a permanent 404 is never retried.
+    import time
     import urllib.error
     import urllib.request
-    try:
-        with urllib.request.urlopen(url, timeout=15) as resp:
-            return resp.read()
-    except (urllib.error.URLError, OSError):
-        return None
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(url, timeout=15) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code in (429, 500, 502, 503, 504) and attempt < attempts - 1:
+                time.sleep(2 * (attempt + 1))
+                continue
+            return None
+        except (urllib.error.URLError, OSError):
+            if attempt < attempts - 1:
+                time.sleep(2 * (attempt + 1))
+                continue
+            return None
+    return None
 
 
 def install_skills(root: str = ".", targets: "list[Path] | None" = None) -> list[str]:

--- a/tina4_python/frond/engine.py
+++ b/tina4_python/frond/engine.py
@@ -1790,14 +1790,13 @@ class Frond:
         """Register a custom filter.
 
         Callable as a classmethod (``Frond.add_filter("money", fn)``) or
-        as an instance method (``engine.add_filter("money", fn)``). The
-        filter is persisted at class level so new instances created by
-        hot-reload inherit it automatically; when called on an existing
-        instance, that instance's local filter map also receives the
-        addition immediately.
+        as an instance method (``engine.add_filter("money", fn)``). Class
+        calls are process-global; instance calls affect that engine only.
+        tina4: ADR-0052.
         """
-        cls._class_filters[name] = fn
-        if instance is not None:
+        if instance is None:
+            cls._class_filters[name] = fn
+        else:
             instance._filters[name] = fn
 
     @_ClassOrInstanceMethod
@@ -1807,8 +1806,9 @@ class Frond:
         Callable as classmethod or instance method. See ``add_filter`` for the
         dual-call semantics.
         """
-        cls._class_globals[name] = value
-        if instance is not None:
+        if instance is None:
+            cls._class_globals[name] = value
+        else:
             instance._globals[name] = value
 
     @_ClassOrInstanceMethod
@@ -1818,8 +1818,9 @@ class Frond:
         Callable as classmethod or instance method. See ``add_filter`` for the
         dual-call semantics.
         """
-        cls._class_tests[name] = fn
-        if instance is not None:
+        if instance is None:
+            cls._class_tests[name] = fn
+        else:
             instance._tests[name] = fn
 
     def render(self, template: str, data: dict = None) -> str:

--- a/tina4_python/frond/engine.py
+++ b/tina4_python/frond/engine.py
@@ -103,6 +103,77 @@ class _LoopContext(dict):
 # found unsupported, use the interpreter) in Frond._compiled_fn.
 _COMPILE_UNSET = object()
 
+# Hard cap on the TEMPLATE caches -- _compiled, _compiled_strings and
+# _compiled_fn (ADR-0004, parity with PHP/Ruby/Node TEMPLATE_CACHE_MAX) --
+# and on _fragment_cache (the {% cache %} tag's runtime store: a rendered
+# fragment is a whole HTML string, the same order of magnitude as a compiled
+# template, not a small per-expression descriptor).
+#
+# An entry here is a token list plus an AST plus (for _compiled_fn) an eval'd
+# render closure, orders of magnitude bigger than one expression descriptor,
+# so the cap sits well below MEMO_CACHE_MAX. 256 is far above any real
+# application's template count, so a normal app never evicts. The cap exists
+# for the workloads that genuinely grow without limit for the life of a
+# worker: render_string() keys on md5(source), so an app that builds template
+# strings dynamically adds an entry per distinct string; in dev the
+# compiled-fn key is 'dev:' + md5(source), so every edit to a template file
+# adds one; and a fragment cache keyed on a dynamic value (a page id, a user
+# id) adds one entry per distinct key.
+TEMPLATE_CACHE_MAX = 256
+
+# Hard cap on every per-expression memo cache that is NOT already bounded by
+# a module-level ``@lru_cache(maxsize=1024)`` (ADR-0004). ``_split_dotted``,
+# ``_has_low_precedence_op``, ``_expr_descriptor`` and ``_split_on_pipe`` are
+# pure functions and already use that decorator directly; ``_filter_chain_cache``
+# is an INSTANCE dict (its callers are bound methods, and lru_cache on a bound
+# method pins ``self`` alive forever, so it cannot use the decorator) and was
+# left as a plain unbounded dict. Same number as the decorator's cap, applied
+# via the manual helper below -- not a new number, the SAME one this file
+# already uses four times over. Mirrors PHP's MEMO_CACHE_MAX and Ruby's
+# MEMO_CACHE_MAX.
+MEMO_CACHE_MAX = 1024
+
+
+def _cap_cache(cache: dict, max_entries: int) -> None:
+    """Keep a memo cache bounded. Call immediately before inserting a new entry.
+
+    Eviction is insertion-ordered (oldest first), not true LRU: a Python dict
+    (3.7+) preserves insertion order, so dropping from the front is cheap,
+    whereas refreshing recency on every cache HIT would add writes to the
+    hottest path in a render and cost more than it saves. Half the cache is
+    dropped at once so the sweep amortises to O(1) per insert.
+
+    Evicting can never change what a render produces: every read site treats
+    a miss as "recompute", so a swept entry is rebuilt on next use.
+    """
+    if len(cache) < max_entries:
+        return
+    drop = max_entries // 2
+    for key in list(cache.keys())[:drop]:
+        del cache[key]
+
+
+def _sweep_expired_cache(cache: dict) -> None:
+    """Drop every TTL-expired entry from a fragment cache: key -> (html, expires_at).
+
+    ``_cap_cache`` bounds a cache by SIZE (insertion order, oldest first) but
+    says nothing about STALENESS: a key that expired and is never visited
+    again would otherwise sit in the dict, still counted against the cap,
+    until something else finally evicts it. An app keying fragments on a
+    dynamic value (a page id, a user id) can churn through many such keys, so
+    staleness has to be swept on its own schedule, not just bounded by count.
+
+    Called on every ``{% cache %}`` render (cheap: bounded by
+    TEMPLATE_CACHE_MAX entries, so at most 256 comparisons) rather than only
+    for the key being read, so an unrelated key's expiry is cleaned up as a
+    side effect of ANY fragment-cache render, not just a future hit on that
+    same key.
+    """
+    now = time.time()
+    expired = [key for key, (_html, expires_at) in cache.items() if expires_at <= now]
+    for key in expired:
+        del cache[key]
+
 # ── Pre-compiled regexes for hot-path operations ───────────────
 _METHOD_CALL_RE = re.compile(r"^(\w+)\s*\((.*)?\)$", re.DOTALL)
 _FUNC_CALL_RE = re.compile(r"^([\w.]+)\s*\((.*)?\)$", re.DOTALL)
@@ -1773,6 +1844,7 @@ class Frond:
         ast = parse(tokens)
         if not debug_mode:
             expires_at = (time.time() + self._cache_ttl) if self._cache_ttl > 0 else 0
+            _cap_cache(self._compiled, TEMPLATE_CACHE_MAX)
             self._compiled[template] = (tokens, ast, expires_at)
             # Prod: the compiled fn is stable per template name (files don't
             # change under a running prod worker), so key it by name.
@@ -1795,6 +1867,7 @@ class Frond:
         if cached is None:
             tokens = _tokenize(source)
             cached = (tokens, parse(tokens))
+            _cap_cache(self._compiled_strings, TEMPLATE_CACHE_MAX)
             self._compiled_strings[key] = cached
         return self._execute_cached(cached[0], cached[1], context, compile_key=key)
 
@@ -1858,6 +1931,7 @@ class Frond:
             return cached
         from tina4_python.frond.compiler import compile_template
         fn = compile_template(ast)
+        _cap_cache(self._compiled_fn, TEMPLATE_CACHE_MAX)
         self._compiled_fn[compile_key] = fn
         return fn
 
@@ -2186,11 +2260,21 @@ class Frond:
         return self._eval_var_inner(expr, context)
 
     def _cached_filter_chain(self, expr: str):
-        """Return parsed filter chain from cache, or parse and cache."""
+        """Return parsed filter chain from cache, or parse and cache.
+
+        ``self._filter_chain_cache`` is an INSTANCE dict (this is a bound
+        method), so it cannot use the module-level ``@lru_cache(maxsize=1024)``
+        the sibling pure-function parsers use (that decorator on a bound
+        method pins ``self`` alive for the life of the cache). Bounded here
+        with the same MEMO_CACHE_MAX via the manual cap helper instead
+        (ADR-0004) — a template that builds expression strings dynamically
+        must not grow this dict without limit for the life of a worker.
+        """
         cached = self._filter_chain_cache.get(expr)
         if cached is not None:
             return cached
         result = _parse_filter_chain(expr)
+        _cap_cache(self._filter_chain_cache, MEMO_CACHE_MAX)
         self._filter_chain_cache[expr] = result
         return result
 
@@ -2622,6 +2706,8 @@ class Frond:
         cache_key = m.group(1) if m else "default"
         ttl = int(m.group(2)) if m and m.group(2) else 60
 
+        _sweep_expired_cache(self._fragment_cache)
+
         # Check cache — a live entry means the body is never rendered
         cached = self._fragment_cache.get(cache_key)
         if cached:
@@ -2631,6 +2717,7 @@ class Frond:
 
         # Render and cache
         rendered = self._render_nodes(node.body, context)
+        _cap_cache(self._fragment_cache, TEMPLATE_CACHE_MAX)
         self._fragment_cache[cache_key] = (rendered, time.time() + ttl)
         return rendered
 

--- a/tina4_python/frond/engine.py
+++ b/tina4_python/frond/engine.py
@@ -232,6 +232,13 @@ _BLOCK_RE = re.compile(
     r"\{%[-\s]*block\s+(\w+)\s*[-]?%\}(.*?)\{%[-\s]*endblock\s*[-]?%\}",
     re.DOTALL,
 )
+# Open/close halves of _BLOCK_RE, used standalone by the depth-aware scanners
+# (_extract_blocks, _substitute_blocks) that pair an open tag with its
+# matching close by counting depth rather than the first endblock found --
+# see _substitute_blocks for why a flat single-regex pass truncates a block
+# that nests another block inside it.
+_BLOCK_OPEN_RE = re.compile(r"\{%[-\s]*block\s+(\w+)\s*[-]?%\}")
+_BLOCK_CLOSE_RE = re.compile(r"\{%[-\s]*endblock\s*[-]?%\}")
 
 
 # ── Ternary helpers ────────────────────────────────────────────
@@ -2000,8 +2007,8 @@ class Frond:
         a single non-greedy regex (which fails on nested block tags).
         """
         blocks = {}
-        block_open = re.compile(r"\{%[-\s]*block\s+(\w+)\s*[-]?%\}")
-        block_close = re.compile(r"\{%[-\s]*endblock\s*[-]?%\}")
+        block_open = _BLOCK_OPEN_RE
+        block_close = _BLOCK_CLOSE_RE
 
         pos = 0
         while pos < len(source):
@@ -2035,6 +2042,101 @@ class Frond:
                 pos = content_start  # malformed, skip forward
 
         return blocks
+
+    def _substitute_blocks(self, source: str, blocks: dict, context: dict) -> str:
+        """Depth-aware block substitution against ``source`` (typically the
+        fully-resolved root template).
+
+        A single non-greedy regex pass (``_BLOCK_RE.sub``) pairs an OUTER
+        block's open tag with the FIRST ``{% endblock %}`` found -- which,
+        when the outer block wraps a NESTED ``{% block %}``, is the nested
+        block's own close tag, not the outer's. That silently truncates the
+        outer block's captured content and drops everything after the inner
+        endblock (the root-nested-block content-loss bug). This scans with
+        an open/close depth counter instead (mirroring ``_extract_blocks``),
+        so an outer block always captures its FULL body, nested child
+        blocks included.
+
+        The content chosen for each block -- the child override in
+        ``blocks`` if present, else the block's own default body -- is then
+        recursively substituted against the SAME ``blocks`` map before being
+        tokenized and rendered, so a block nested inside another block
+        resolves correctly regardless of which template in the inheritance
+        chain declared the nesting (the root, an intermediate, however many
+        levels deep).
+
+        ``{{ parent() }}`` / ``{{ super() }}`` inside a block still render
+        that block's OWN default content at this level (lazy, on first
+        call) -- unaffected by the depth-aware scan.
+        """
+        block_open = _BLOCK_OPEN_RE
+        block_close = _BLOCK_CLOSE_RE
+        engine = self
+        length = len(source)
+        pieces = []
+        pos = 0
+
+        while pos < length:
+            m_open = block_open.search(source, pos)
+            if not m_open:
+                pieces.append(source[pos:])
+                break
+
+            pieces.append(source[pos:m_open.start()])  # untouched text before the tag
+
+            name = m_open.group(1)
+            content_start = m_open.end()
+            depth = 1
+            scan = content_start
+            close_match = None
+
+            while depth > 0 and scan < length:
+                next_open = block_open.search(source, scan)
+                next_close = block_close.search(source, scan)
+
+                if next_close is None:
+                    break  # malformed — no matching endblock
+
+                if next_open and next_open.start() < next_close.start():
+                    depth += 1
+                    scan = next_open.end()
+                else:
+                    depth -= 1
+                    if depth == 0:
+                        close_match = next_close
+                    else:
+                        scan = next_close.end()
+
+            if close_match is None:
+                # Malformed template (no matching endblock) — keep the rest
+                # verbatim rather than lose it, the same leniency
+                # _extract_blocks applies to this case.
+                pieces.append(source[m_open.start():])
+                pos = length
+                break
+
+            parent_content = source[content_start:close_match.start()]
+            block_source = blocks.get(name, parent_content)
+            resolved_source = engine._substitute_blocks(block_source, blocks, context)
+
+            rendered_parent = None
+
+            def get_parent(_default=parent_content):
+                nonlocal rendered_parent
+                if rendered_parent is None:
+                    rendered_parent = SafeString(
+                        engine._render_tokens(_tokenize(_default), context)
+                    )
+                return rendered_parent
+
+            block_ctx = dict(context)
+            block_ctx["parent"] = get_parent
+            block_ctx["super"] = get_parent
+
+            pieces.append(engine._render_tokens(_tokenize(resolved_source), block_ctx))
+            pos = close_match.end()
+
+        return "".join(pieces)
 
     def _render_with_blocks(self, parent_source: str, context: dict, child_blocks: dict) -> str:
         """Render parent template, replacing blocks with child content.
@@ -2077,36 +2179,10 @@ class Frond:
             return self._render_with_blocks(grandparent_source, context, merged_blocks)
 
         # --- Leaf parent (no extends) — resolve blocks and render ---
-        engine = self
-
-        def replace_block(m):
-            name = m.group(1)
-            parent_content = m.group(2)
-            block_source = child_blocks.get(name, parent_content)
-
-            # Make parent() and super() available inside child blocks
-            # They return the rendered parent block content
-            rendered_parent = None
-
-            def get_parent():
-                nonlocal rendered_parent
-                if rendered_parent is None:
-                    rendered_parent = SafeString(
-                        engine._render_tokens(_tokenize(parent_content), context)
-                    )
-                return rendered_parent
-
-            # Inject parent/super into a block-local context
-            block_ctx = dict(context)
-            block_ctx["parent"] = get_parent
-            block_ctx["super"] = get_parent
-
-            return engine._render_tokens(_tokenize(block_source), block_ctx)
-
-        pattern = _BLOCK_RE
-
-        # First pass: replace blocks
-        result = pattern.sub(replace_block, parent_source)
+        # First pass: depth-aware block substitution (handles a block nested
+        # inside another block at ANY level of the chain, including the root
+        # itself — see _substitute_blocks).
+        result = self._substitute_blocks(parent_source, child_blocks, context)
         # Second pass: render remaining tokens (text, vars outside blocks)
         return self._render_tokens(_tokenize(result), context)
 

--- a/tina4_python/frond/engine.py
+++ b/tina4_python/frond/engine.py
@@ -135,6 +135,28 @@ _SPACELESS_RE = re.compile(r">\s+<")
 _STRIPTAGS_RE = re.compile(r"<[^>]+>")
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 _EXTENDS_RE = re.compile(r"\{%[-\s]*extends\s+[\"'](.+?)[\"']\s*[-]?%\}")
+
+
+def _extends_target(source: str) -> str:
+    """Return this template's OWN ``{% extends %}`` parent name, or ``""``.
+
+    A template may extend at most one parent. Before 3.13.100 a SECOND
+    ``{% extends %}`` tag anywhere in the source was silently invisible: only
+    the first (leading) occurrence was ever matched, and the rest of the
+    child's non-block content -- including the second extends tag -- was
+    already discarded the same way ordinary non-block child content is
+    discarded during inheritance. That hid what is almost always a mistake
+    (a copy-paste, a bad merge) with zero signal. Raise clearly instead, the
+    same policy 3.13.89 applied to an unknown tag.
+    """
+    matches = _EXTENDS_RE.findall(source)
+    if len(matches) > 1:
+        raise ValueError(
+            f'Frond: template has {len(matches)} "{{% extends %}}" tags -- '
+            "a template can extend only one parent"
+        )
+    match = _EXTENDS_RE.match(source.lstrip())
+    return match.group(1) if match else ""
 _BLOCK_RE = re.compile(
     r"\{%[-\s]*block\s+(\w+)\s*[-]?%\}(.*?)\{%[-\s]*endblock\s*[-]?%\}",
     re.DOTALL,
@@ -1871,9 +1893,8 @@ class Frond:
                              template: str = None, compile_key: str = None) -> str:
         """Execute with the source, its tokens and its AST all available."""
         # Handle extends first
-        extends_match = _EXTENDS_RE.match(source.lstrip())
-        if extends_match:
-            parent_name = extends_match.group(1)
+        parent_name = _extends_target(source)
+        if parent_name:
             parent_source = self._load(parent_name)
             child_blocks = self._extract_blocks(source)
             return self._render_with_blocks(parent_source, context, child_blocks)
@@ -1886,9 +1907,8 @@ class Frond:
     def _execute(self, source: str, context: dict) -> str:
         """Execute template source against context."""
         # Handle extends first
-        extends_match = _EXTENDS_RE.match(source.lstrip())
-        if extends_match:
-            parent_name = extends_match.group(1)
+        parent_name = _extends_target(source)
+        if parent_name:
             parent_source = self._load(parent_name)
 
             # Extract blocks from child
@@ -1954,9 +1974,8 @@ class Frond:
         the parent block's content (standard Twig/Jinja2 behavior).
         """
         # --- Multi-level extends: check if parent itself extends a grandparent ---
-        extends_match = _EXTENDS_RE.match(parent_source.lstrip())
-        if extends_match:
-            grandparent_name = extends_match.group(1)
+        grandparent_name = _extends_target(parent_source)
+        if grandparent_name:
             grandparent_source = self._load(grandparent_name)
 
             # Extract block defaults defined in the parent template

--- a/uv.lock
+++ b/uv.lock
@@ -1396,7 +1396,7 @@ wheels = [
 
 [[package]]
 name = "tina4-python"
-version = "3.13.99"
+version = "3.13.100"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary\n\n- complete the audited Tina4 3.13.100 parity work\n- make Frond class/global/test extensions process-global while keeping instance extensions local\n- include resilient skill installation and broaden the tina4-js trigger spellings\n- document tina4js 1.5.2 HTML-comment interpolation behavior\n\n## Verification\n\n- 5,550 tests passed; targeted ODBC contract 11/11\n- feature audit plans closed\n- shared language-port fixtures validated\n\nThis release intentionally allows parity corrections before the 3.14.0 stability boundary.