### PR TITLE
Fix failing metrics contract CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,8 +257,8 @@ jobs:
         run: |
           cli_dir="$(mktemp -d)"
           trap 'rm -rf "$cli_dir"' EXIT
-          curl -fsSLo "$cli_dir/tina4-linux-amd64" https://github.com/tina4stack/tina4/releases/download/v3.8.71/tina4-linux-amd64
-          curl -fsSLo "$cli_dir/SHA256SUMS" https://github.com/tina4stack/tina4/releases/download/v3.8.71/SHA256SUMS
+          curl -fsSLo "$cli_dir/tina4-linux-amd64" https://github.com/tina4stack/tina4/releases/download/v3.8.76/tina4-linux-amd64
+          curl -fsSLo "$cli_dir/SHA256SUMS" https://github.com/tina4stack/tina4/releases/download/v3.8.76/SHA256SUMS
           (cd "$cli_dir" && grep ' tina4-linux-amd64$' SHA256SUMS | sha256sum -c -)
           sudo install -m 0755 "$cli_dir/tina4-linux-amd64" /usr/local/bin/tina4
           tina4 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,7 +253,7 @@ jobs:
           EOF
           cat /etc/odbcinst.ini
 
-      - name: Install native Tina4 CLI 3.8.71
+      - name: Install native Tina4 CLI 3.8.76
         run: |
           cli_dir="$(mktemp -d)"
           trap 'rm -rf "$cli_dir"' EXIT


### PR DESCRIPTION
## What changed
- install signed Tina4 client 3.8.76 in CI
- preserve the strict `has_referencing_test` native metrics contract

## Verification
Focused native handoff tests pass against client 3.8.76. Repository-specific regression fixes and exact evidence are included in the commits.