### PR TITLE
Release 3.13.103

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,17 +26,26 @@ jobs:
       - name: Install dependencies
         run: pip install uv
 
-      - name: Set version from tag
+      - name: Verify tag matches source version
         run: |
           VERSION="${GITHUB_REF_NAME}"
-          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
-          echo "Building version $VERSION"
+          SOURCE_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          RUNTIME_VERSION="$(PYTHONPATH=. python -c 'import tina4_python; print(tina4_python.__version__)')"
+          test "$SOURCE_VERSION" = "$VERSION" || {
+            echo "::error::Tag $VERSION does not match pyproject.toml $SOURCE_VERSION"
+            exit 1
+          }
+          test "$RUNTIME_VERSION" = "$VERSION" || {
+            echo "::error::Tag $VERSION does not match runtime $RUNTIME_VERSION"
+            exit 1
+          }
+          echo "Building verified version $VERSION"
 
       - name: Build package
         run: uv build
 
       - name: Publish to PyPI
-        run: uv publish || echo "Already published — skipping"
+        run: uv publish
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,35 @@ https://tina4.com/python/36-releases
 This file records framework-specific changes. The release notes above remain the
 authority for shipped versions.
 
-## 3.13.101
+## 3.13.103
+
+### Metrics reports what it can prove
+
+- Require signed Tina4 client 3.8.76 for the native metrics handoff.
+- Expose `has_referencing_test` as a source-reference signal. It does not claim
+  that a test ran or that coverage exists.
+- Fail when the native client is stale instead of falling back to a second
+  framework-owned analyser.
+
+### Frond stays stable and gets smaller
+
+- Split expression parsing and evaluation into focused internal steps.
+- Preserve public APIs and the shared 84-case expression corpus across all four
+  languages.
+
+### One client starts every project
+
+- Lead framework skills with `tina4 init` and `tina4 serve`.
+- Keep scaffolding guidance visible and separate runtime dependencies from
+  language extensions.
+
+### Release integrity
+
+- Align source, runtime, package, lockfile, and AI-facing guide versions.
+- Reject a release tag that does not match the source package version before
+  any registry publish begins.
+
++## 3.13.101
 
 ### Breaking: metrics has one owner
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Tina4 Python
 
-Version 3.13.101 - Lightweight Python web framework. See https://tina4.com for full documentation.
+Version 3.13.103 - Lightweight Python web framework. See https://tina4.com for full documentation.
 
 ## Build & Test
 
@@ -857,7 +857,7 @@ uv run tina4python test   # Discovers @tests in src/**/*.py
 - SSE/Streaming via `response.stream()` — Server-Sent Events support for real-time data push. Pass an async generator; framework handles chunked transfer encoding, `text/event-stream` content type, and connection keep-alive
 - MCP server (`tina4_python.mcp`): built-in dev tools auto-start when MCP is a capability of the deployment. Developer API: `McpServer`, `@mcp_tool`, `@mcp_resource`. JSON-RPC 2.0 over SSE. **Security is a two-layer gate (v3.13.40):** `is_enabled()` is a pure capability gate (explicit `TINA4_MCP` wins, else `TINA4_DEBUG`; host-independent), and `is_request_allowed(remote_ip, has_valid_token)` authorises each request on the RAW socket peer (`request.remote_ip`, never X-Forwarded-For): loopback always; a remote caller needs `TINA4_MCP_REMOTE=true` AND a token matching `TINA4_MCP_TOKEN` (fallback `TINA4_API_KEY`; sent as Authorization Bearer / X-MCP-Token / X-Api-Key; no configured token means remote is always denied). All MCP surfaces (REST shim, JSON-RPC, SSE) 404 a disallowed caller. `database_query` is SELECT/WITH-only and rejects stacked statements; the file tools are sandboxed to the project root. `is_localhost()` is informational only, not the gate
 - Tests: 5,063 passing, 0 failures, **0 skipped** — measured 2026-08-06 on the lab (Ubuntu 24.04.4 LTS x86_64, Python 3.13.3, live services, `TINA4_REQUIRE_SERVICES=1`, 456s, run as root). **Firebird is NOT excluded.** The lab provisions a live Firebird 5 (`firebirdsql/firebird:5` on :3050, `TINA4_TEST_FIREBIRD_URL`) and those tests run. What IS deliberate is Firebird's absence from the `TINA4_REQUIRE_SERVICES` keyword gate in `tests/conftest.py`: GitHub CI does not provision Firebird, so a Firebird skip has to stay green *there*. Those are two different things and this line used to conflate them into "excluded by design", which read as "the Firebird tests do not run" — they do. **Nothing skips any more.** The last skip was `tests/test_session_backend_failure.py` `[needs:no-dac-override]`: the suite runs as root, root holds `CAP_DAC_OVERRIDE`, so a write went straight through a 0400 file and no real `EACCES` was reachable — and as root the second `save()` returned `True`, so that skip was hiding a FAILING assertion, not merely an unrunnable one. The test now stops being root for the length of the failing write (`os.seteuid` to `nobody`; the saved uid stays 0, so a `finally` always restores it) and the kernel raises the genuine errno-13 the test asserts. Two parts of that are load-bearing: the log directory is handed to the same uid, because dropping the uid otherwise denies `Log.error` as well and the EACCES under test goes unrecorded (`_LogWriter.write` swallows `OSError` unless `TINA4_LOG_STRICT`); and the fixture root is its own 0755 `mkdtemp` rather than `tmp_path`, whose 0700 root-owned parents make every denial a directory traversal, which would pass for the wrong reason. Re-measure with `.venv/bin/python -m pytest tests/ -q` and quote the summary line, never the exit code
-- Version: 3.13.101
+- Version: 3.13.103
 
 ## Links
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tina4-python"
-version = "3.13.101"
+version = "3.13.103"
 description = "Tina4 Python v3 — Zero-dependency, lightweight web framework"
 authors = [
     {name = "Andre van Zuydam", email = "andrevanzuydam@gmail.com"}

--- a/tina4_python/__init__.py
+++ b/tina4_python/__init__.py
@@ -51,7 +51,7 @@ def _resolve_version() -> str:
     #
     # test_version_constant.py now asserts this literal equals the pyproject
     # version, so the release bump cannot leave it behind again.
-    return "3.13.101"
+    return "3.13.103"
 
 
 __version__ = _resolve_version()

--- a/uv.lock
+++ b/uv.lock
@@ -1396,7 +1396,7 @@ wheels = [
 
 [[package]]
 name = "tina4-python"
-version = "3.13.101"
+version = "3.13.103"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 3.13.103\n\nRestores one public version across Python, PHP, Ruby, and Node.js after the incomplete 3.13.102 registry publish.\n\n- requires signed Tina4 client 3.8.76 for native metrics handoff\n- preserves Frond APIs and the shared 84-case expression corpus\n- aligns source, runtime, package, lockfile, and AI guide versions\n- rejects tag/source version mismatches before publishing\n- adds no runtime package dependencies\n\n## Root lab gate\n\n- Python: 5,527 passed\n- PHP: 5,444 tests / 19,094 assertions\n- Ruby: 5,449 examples / 0 failures\n- Node.js: 8,436 passed / 0 skipped\n\nCo-Authored-By: Tina4 <82961293+tina4stack@users.noreply.github.com>