### PR TITLE
fix(websocket): make @websocket usable from the package name

### DIFF
--- a/.claude/skills/tina4-developer-python/references/auth-and-services.md
+++ b/.claude/skills/tina4-developer-python/references/auth-and-services.md
@@ -264,7 +264,7 @@ async def contact(request, response):
 
 ### Server
 ```python
-from tina4_python.core.router import websocket
+from tina4_python import websocket
 
 @websocket("/ws/chat")
 async def chat(connection):
@@ -273,8 +273,9 @@ async def chat(connection):
         await connection.broadcast(message.data)
 ```
 
-> Import `websocket` from `tina4_python.core.router` — it is not re-exported from the top-level
-> `tina4_python` package.
+> `from tina4_python import websocket` is the documented form (the subpackage is
+> callable and forwards to `core.router.websocket`). `from tina4_python.core.router
+> import websocket` still works and is the spelling mypy/pyright accept.
 
 ### Client (frond.js)
 ```javascript

--- a/.claude/skills/tina4-maintainer/references/subsystems.md
+++ b/.claude/skills/tina4-maintainer/references/subsystems.md
@@ -81,11 +81,15 @@ Fully native RFC 6455 implementation (~300-400 lines per language). No third-par
 
 ### Route-Based Registration (Python)
 
-`websocket` is NOT a top-level export — `from tina4_python import websocket` imports the
-`tina4_python.websocket` **module**, not the decorator. Import it from the router:
+`from tina4_python import websocket` is callable: the `tina4_python.websocket`
+subpackage is a callable module that forwards to `core.router.websocket`. Both
+spellings work. `from tina4_python.websocket import WebSocketServer` still
+imports the RFC 6455 types. The router import is the form static type checkers
+accept (`Module not callable` otherwise):
 
 ```python
-from tina4_python.core.router import websocket
+from tina4_python import websocket
+# or: from tina4_python.core.router import websocket
 
 # The handler is event-based: (connection, event, data). `event` is "open",
 # "message", or "close"; `data` is the payload (str for "message", None otherwise).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ Bug release. Route inspection stops touching the app; Firebird's migration
 ledger tolerates whatever case the driver hands back; PHP loses a colon-in-
 filename that broke Windows checkouts.
 
+### `@websocket` works from the package name
+
+- `from tina4_python import websocket` is callable. The `tina4_python.websocket`
+  subpackage is a callable module that forwards to `core.router.websocket`, so
+  the documented landing-page form no longer raises `TypeError: 'module' object
+  is not callable` and auto-discovery no longer drops the rest of that route
+  file. `from tina4_python.websocket import WebSocketServer` is unchanged.
+- Python-only (import machinery binds the subpackage onto the parent name).
+  PHP/Ruby/Node have no same-name collision.
+
 ### Route inspection scans, never boots
 
 - `tina4 routes` now walks canonical route files and never executes the

--- a/plan/websocket-decorator-shadowed.md
+++ b/plan/websocket-decorator-shadowed.md
@@ -1,0 +1,43 @@
+# Task: `from tina4_python import websocket` is callable (PY-FW-03)
+
+## Outcome
+Documented `from tina4_python import websocket` + `@websocket("/ws")` works on
+3.13.105 without turning `import tina4_python.websocket as ws` into a function.
+Review blockers on `fix/websocket-decorator-shadowed` landed before the PR.
+
+## Scope
+- [x] Confirm defect on origin/v3 (module not callable)
+- [x] Guard `sys.modules` lookup; `__call__(*args, **kwargs)`
+- [x] Rewrite false "re-export race" rationale (comment + tests)
+- [x] Pointer comment in `tina4_python/__init__.py` eager tuple
+- [x] Tests: re-export guard is `isinstance ModuleType` + `WebSocketServer`;
+      decorator `__code__` identity; backplane submodule import
+- [x] CHANGELOG under 3.13.105
+- [x] Flip two `.claude/skills/` lines that still deny the top-level form
+- [ ] PR vs `v3` — disclose mypy/pyright `Module not callable`
+
+## Parity
+| Surface | Python | PHP | Ruby | Node |
+|---------|--------|-----|------|------|
+| package-name decorator shadowing | this PR | n/a (no same-name subpackage) | n/a | n/a |
+
+Python-only: CPython binds `tina4_python.websocket` to the subpackage.
+
+## Tests (written first, real — no mocks, positive + negative)
+- [x] package attribute callable; `@websocket` registers a path
+- [x] `import tina4_python.websocket as ws` stays a ModuleType with `WebSocketServer`
+- [x] `from tina4_python.websocket import backplane` still resolves
+- [x] package decorator `__code__` is router decorator `__code__`
+- [x] negative: four decorator tests fail on unfixed origin/v3 (already measured)
+- [x] full suite at HEAD: 13 failed / 5026 passed / 628 skipped (Linux, CPython 3.13). Same 13 env failures as origin/v3 (connect-timeout, port-takeover, queue backend names, redis session). test_swagger_contract.py ignored (no openapi_spec_validator).
+
+## Bugs
+- [ ] PY-FW-03: `from tina4_python import websocket` is the module, TypeError at decorate
+- [ ] review: commit claimed import-order rebind; measured false after first load
+- [ ] review: unguarded `_sys.modules[__name__]` KeyError without sys.modules entry
+
+## Commits
+- cf4d676  fix(websocket): make @websocket usable from the package name
+- (follow-up hash after review fixes)
+
+## Status: In Progress

--- a/plan/websocket-decorator-shadowed.md
+++ b/plan/websocket-decorator-shadowed.md
@@ -38,6 +38,6 @@ Python-only: CPython binds `tina4_python.websocket` to the subpackage.
 
 ## Commits
 - cf4d676  fix(websocket): make @websocket usable from the package name
-- (follow-up hash after review fixes)
+- 362a679  fix(websocket): correct callable-module rationale
 
-## Status: In Progress
+## Status: Local complete. PR blocked: MichaelC8E has no write on tina4stack/tina4-python and no fork; `gh` not logged in.

--- a/plan/websocket-decorator-shadowed.md
+++ b/plan/websocket-decorator-shadowed.md
@@ -40,4 +40,4 @@ Python-only: CPython binds `tina4_python.websocket` to the subpackage.
 - cf4d676  fix(websocket): make @websocket usable from the package name
 - 362a679  fix(websocket): correct callable-module rationale
 
-## Status: Local complete. PR blocked: MichaelC8E has no write on tina4stack/tina4-python and no fork; `gh` not logged in.
+## Status: Ready for PR vs v3

--- a/tests/test_websocket_decorator_name.py
+++ b/tests/test_websocket_decorator_name.py
@@ -1,26 +1,29 @@
-"""`from tina4_python import websocket` must give the decorator, not the module.
+"""`from tina4_python import websocket` must give a callable module, not a bare module.
 
 `tina4_python.websocket` is two things at once: the RFC 6455 subpackage, and —
 to every reader of the docs — the route decorator that sits beside @get/@post
 in ``core.router``. Python binds a submodule onto its parent package the moment
 the submodule is imported, so the name resolved to the module and the
-documented usage died at import time::
+documented usage died at decorate time::
 
     from tina4_python import websocket
 
     @websocket("/ws")            # TypeError: 'module' object is not callable
     async def chat(connection, event, data): ...
 
-which takes the whole route file with it. Reproduced on 3.13.105:
-``type(tina4_python.websocket).__name__ == "module"``, ``callable(...) is False``.
+Auto-discovery logged one ERROR and dropped every route from that line onward.
+Reproduced on 3.13.105: ``callable(tina4_python.websocket) is False``.
 
-Re-exporting the decorator from ``tina4_python/__init__.py`` cannot fix this —
-importing the subpackage rebinds the attribute over the re-export afterwards,
-so the failure would come and go with import order. The module is callable
-instead, which is why `test_still_callable_after_the_submodule_is_imported`
-matters: it is the case a re-export would lose.
+A re-export of ``core.router.websocket`` onto ``tina4_python.websocket`` would
+make ``from tina4_python import websocket`` callable, but ``import
+tina4_python.websocket as ws`` would then be the function — ``ws.WebSocketServer``
+breaks. ``test_still_callable_after_the_submodule_is_imported`` pins the
+re-export-killing half: the alias must stay a ``ModuleType`` that still
+exposes ``WebSocketServer``.
 """
 from __future__ import annotations
+
+import types
 
 import pytest
 
@@ -51,23 +54,27 @@ class TestDecoratorSurface:
         assert chat.__name__ == "chat", "decorator must return the handler unchanged"
 
     def test_matches_the_router_decorator(self, clean_ws_routes):
-        """Both spellings must land the same route."""
+        """Package spelling is the router decorator, not a second implementation."""
         from tina4_python.core.router import websocket as router_websocket
 
-        @router_websocket("/ws/a")
+        assert tina4_python.websocket("/p").__code__ is router_websocket("/p").__code__
+
+        @router_websocket("/ws/a/{room}")
         async def via_router(connection, event, data):
             return None
 
-        @tina4_python.websocket("/ws/b")
+        @tina4_python.websocket("/ws/b/{room}")
         async def via_package(connection, event, data):
             return None
 
         registered = {r["path"]: r for r in clean_ws_routes}
-        assert registered["/ws/a"].keys() == registered["/ws/b"].keys()
-        assert registered["/ws/b"]["handler"] is via_package
+        assert registered["/ws/a/{room}"]["param_names"] == registered["/ws/b/{room}"]["param_names"] == ["room"]
+        assert registered["/ws/a/{room}"]["auth_required"] is False
+        assert registered["/ws/b/{room}"]["auth_required"] is False
+        assert registered["/ws/b/{room}"]["handler"] is via_package
 
     def test_still_callable_after_the_submodule_is_imported(self):
-        """The case a plain re-export in __init__.py would lose."""
+        """A re-export would make `import tina4_python.websocket as ws` a function."""
         import importlib
 
         import tina4_python.websocket as ws_module
@@ -75,6 +82,8 @@ class TestDecoratorSurface:
         importlib.reload(importlib.import_module("tina4_python.websocket"))
         assert callable(tina4_python.websocket)
         assert callable(ws_module)
+        assert isinstance(ws_module, types.ModuleType)
+        assert ws_module.WebSocketServer.__name__ == "WebSocketServer"
 
 
 class TestModuleSurfaceSurvives:
@@ -100,8 +109,13 @@ class TestModuleSurfaceSurvives:
         assert "compute_accept_key" in ws.__all__
 
     def test_it_is_still_a_module(self):
-        import types
-
         import tina4_python.websocket as ws
 
         assert isinstance(ws, types.ModuleType)
+
+    def test_backplane_submodule_still_imports(self):
+        from tina4_python.websocket import backplane
+        import tina4_python.websocket.backplane as backplane_mod
+
+        assert backplane is backplane_mod
+        assert callable(backplane.create_backplane)

--- a/tests/test_websocket_decorator_name.py
+++ b/tests/test_websocket_decorator_name.py
@@ -1,0 +1,107 @@
+"""`from tina4_python import websocket` must give the decorator, not the module.
+
+`tina4_python.websocket` is two things at once: the RFC 6455 subpackage, and —
+to every reader of the docs — the route decorator that sits beside @get/@post
+in ``core.router``. Python binds a submodule onto its parent package the moment
+the submodule is imported, so the name resolved to the module and the
+documented usage died at import time::
+
+    from tina4_python import websocket
+
+    @websocket("/ws")            # TypeError: 'module' object is not callable
+    async def chat(connection, event, data): ...
+
+which takes the whole route file with it. Reproduced on 3.13.105:
+``type(tina4_python.websocket).__name__ == "module"``, ``callable(...) is False``.
+
+Re-exporting the decorator from ``tina4_python/__init__.py`` cannot fix this —
+importing the subpackage rebinds the attribute over the re-export afterwards,
+so the failure would come and go with import order. The module is callable
+instead, which is why `test_still_callable_after_the_submodule_is_imported`
+matters: it is the case a re-export would lose.
+"""
+from __future__ import annotations
+
+import pytest
+
+import tina4_python
+from tina4_python.core import router as router_module
+
+
+@pytest.fixture
+def clean_ws_routes():
+    """Route registration mutates a module-level list — put it back."""
+    saved = list(router_module._ws_routes)
+    yield router_module._ws_routes
+    router_module._ws_routes[:] = saved
+
+
+class TestDecoratorSurface:
+    def test_package_attribute_is_callable(self):
+        assert callable(tina4_python.websocket)
+
+    def test_decorator_registers_the_route(self, clean_ws_routes):
+        from tina4_python import websocket
+
+        @websocket("/ws/chat/{room}")
+        async def chat(connection, event, data):
+            return None
+
+        assert [r["path"] for r in clean_ws_routes if r["path"] == "/ws/chat/{room}"]
+        assert chat.__name__ == "chat", "decorator must return the handler unchanged"
+
+    def test_matches_the_router_decorator(self, clean_ws_routes):
+        """Both spellings must land the same route."""
+        from tina4_python.core.router import websocket as router_websocket
+
+        @router_websocket("/ws/a")
+        async def via_router(connection, event, data):
+            return None
+
+        @tina4_python.websocket("/ws/b")
+        async def via_package(connection, event, data):
+            return None
+
+        registered = {r["path"]: r for r in clean_ws_routes}
+        assert registered["/ws/a"].keys() == registered["/ws/b"].keys()
+        assert registered["/ws/b"]["handler"] is via_package
+
+    def test_still_callable_after_the_submodule_is_imported(self):
+        """The case a plain re-export in __init__.py would lose."""
+        import importlib
+
+        import tina4_python.websocket as ws_module
+
+        importlib.reload(importlib.import_module("tina4_python.websocket"))
+        assert callable(tina4_python.websocket)
+        assert callable(ws_module)
+
+
+class TestModuleSurfaceSurvives:
+    """Making the module callable must not cost it its exports."""
+
+    def test_documented_names_still_import(self):
+        from tina4_python.websocket import (
+            WebSocketConnection,
+            WebSocketManager,
+            WebSocketServer,
+            compute_accept_key,
+        )
+
+        assert WebSocketServer.__name__ == "WebSocketServer"
+        assert WebSocketConnection.__name__ == "WebSocketConnection"
+        assert WebSocketManager.__name__ == "WebSocketManager"
+        assert callable(compute_accept_key)
+
+    def test_dunder_all_intact(self):
+        import tina4_python.websocket as ws
+
+        assert "WebSocketServer" in ws.__all__
+        assert "compute_accept_key" in ws.__all__
+
+    def test_it_is_still_a_module(self):
+        import types
+
+        import tina4_python.websocket as ws
+
+        assert isinstance(ws, types.ModuleType)

--- a/tina4_python/__init__.py
+++ b/tina4_python/__init__.py
@@ -74,6 +74,11 @@ from tina4_python.core.router import (  # noqa: E402, F401
     noauth, secured, cached, middleware, template,
     Router, RouteGroup,
 )
+# websocket is not in that tuple. The tina4_python.websocket *subpackage* is
+# itself callable (see tina4_python/websocket/__init__.py) so
+# `from tina4_python import websocket` reaches core.router.websocket without
+# turning `import tina4_python.websocket as ws` into a function. A re-export
+# here would do the latter.
 from tina4_python.core.constants import (  # noqa: E402, F401
     HTTP_OK, HTTP_CREATED, HTTP_ACCEPTED, HTTP_NO_CONTENT,
     HTTP_MOVED, HTTP_REDIRECT, HTTP_NOT_MODIFIED,

--- a/tina4_python/websocket/__init__.py
+++ b/tina4_python/websocket/__init__.py
@@ -966,30 +966,31 @@ __all__ = [
 
 
 # ── `@websocket("/path")` on the package name ───────────────────────────────
-# `tina4_python.websocket` is two things at once: this module, and — to every
-# reader of the docs — the route decorator that sits beside @get/@post in
-# core.router. Python binds a submodule onto its parent package as soon as the
-# submodule is imported, so the name resolved to this module and
+# `tina4_python.websocket` is two things at once: this RFC 6455 subpackage,
+# and — to every reader of the docs — the route decorator beside @get/@post.
+# Python binds a submodule onto its parent as soon as the submodule loads, so
 #
 #     from tina4_python import websocket
-#
 #     @websocket("/ws")            # TypeError: 'module' object is not callable
-#     async def chat(...): ...
 #
-# took the whole route file down at import time.
+# died at decorate time and auto-discovery dropped every route from that line
+# onward.
 #
-# Re-exporting the decorator from tina4_python/__init__.py cannot win that
-# race: whenever anything imports this subpackage, the import machinery
-# rebinds the attribute over it. Making the module itself callable is the one
-# fix that keeps both surfaces intact — `from tina4_python.websocket import
-# WebSocketServer` still resolves, and `@websocket("/ws")` now reaches
-# core.router.websocket. The import is deferred to call time so this module
-# stays free of a core.router dependency at import.
+# A re-export in tina4_python/__init__.py AFTER core.server has already loaded
+# this subpackage is stable (importlib setattr happens on first load only).
+# That still fails the other public surface: `import tina4_python.websocket as
+# ws` would then return the function, so `ws.WebSocketServer` breaks. Making
+# this module callable keeps both: the package name decorates, and the
+# subpackage stays a module. Forward *args/**kwargs so this spelling cannot
+# drift from core.router.websocket. Guard sys.modules — a loader that execs
+# this file without registering it must not KeyError.
 class _CallableWebSocketModule(_ModuleType):
-    def __call__(self, path: str):
+    def __call__(self, *args, **kwargs):
         from tina4_python.core.router import websocket as _websocket_route
 
-        return _websocket_route(path)
+        return _websocket_route(*args, **kwargs)
 
 
-_sys.modules[__name__].__class__ = _CallableWebSocketModule
+_self = _sys.modules.get(__name__)
+if _self is not None:
+    _self.__class__ = _CallableWebSocketModule

--- a/tina4_python/websocket/__init__.py
+++ b/tina4_python/websocket/__init__.py
@@ -22,6 +22,8 @@ import os
 import uuid
 import time
 from typing import Callable
+import sys as _sys
+from types import ModuleType as _ModuleType
 
 MAGIC_STRING = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
@@ -961,3 +963,33 @@ __all__ = [
     "OP_TEXT", "OP_BINARY", "OP_CLOSE", "OP_PING", "OP_PONG",
     "CLOSE_NORMAL", "CLOSE_GOING_AWAY", "CLOSE_PROTOCOL_ERROR", "CLOSE_TOO_LARGE",
 ]
+
+
+# ── `@websocket("/path")` on the package name ───────────────────────────────
+# `tina4_python.websocket` is two things at once: this module, and — to every
+# reader of the docs — the route decorator that sits beside @get/@post in
+# core.router. Python binds a submodule onto its parent package as soon as the
+# submodule is imported, so the name resolved to this module and
+#
+#     from tina4_python import websocket
+#
+#     @websocket("/ws")            # TypeError: 'module' object is not callable
+#     async def chat(...): ...
+#
+# took the whole route file down at import time.
+#
+# Re-exporting the decorator from tina4_python/__init__.py cannot win that
+# race: whenever anything imports this subpackage, the import machinery
+# rebinds the attribute over it. Making the module itself callable is the one
+# fix that keeps both surfaces intact — `from tina4_python.websocket import
+# WebSocketServer` still resolves, and `@websocket("/ws")` now reaches
+# core.router.websocket. The import is deferred to call time so this module
+# stays free of a core.router dependency at import.
+class _CallableWebSocketModule(_ModuleType):
+    def __call__(self, path: str):
+        from tina4_python.core.router import websocket as _websocket_route
+
+        return _websocket_route(path)
+
+
+_sys.modules[__name__].__class__ = _CallableWebSocketModule


### PR DESCRIPTION
**Issue:** `from tina4_python import websocket` imported the RFC 6455 *module*, not the route decorator. `@websocket("/ws")` then raised `TypeError: 'module' object is not callable`. Auto-discovery logged one error and dropped every route from that line onward. The landing page and the WebSocket spec both teach this import.

**Fix:** make `tina4_python.websocket` a callable module that forwards to `core.router.websocket`. `from tina4_python.websocket import WebSocketServer` still works. A re-export was not used: it would make `import tina4_python.websocket as ws` return the function and break `ws.WebSocketServer`.

mypy/pyright still flag `Module not callable` on the package spelling; import from `core.router` if that matters.