### PR TITLE
fix(cache): ResponseCache replays one session's response to another

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -930,6 +930,114 @@ class TestSharedCacheAuthorization:
         assert header_of(out, "X-Cache") == "HIT"
 
 
+class TestNoStoreAndPrivate:
+    """RFC 9111 s3: "no-store" forbids storage in ANY cache and "private"
+    forbids it in a shared one.
+
+    Neither was honoured before 3.13.108, so a handler had no way at all to keep
+    a response out of this cache — setting the correct standard header did
+    nothing and the body was still replayed to the next caller of that URL.
+    """
+
+    @pytest.mark.parametrize("directive", ["no-store", "private", "no-cache"])
+    def test_a_response_refusing_storage_is_not_stored(self, directive):
+        cache = ResponseCache(ttl=60)
+        cache.clear_cache()
+
+        first = make_request(url=f"/api/secret/{directive}")
+        resp = make_response(body='{"token": "ALICE-SECRET"}')
+        resp.header("Cache-Control", directive)
+        cache.before_cache(first, resp)
+        cache.after_cache(first, resp)
+
+        later = make_request(url=f"/api/secret/{directive}")
+        out = serve(cache, later, make_response())
+        assert "ALICE-SECRET" not in body_of(out)
+
+    def test_the_directive_is_read_as_a_token_not_a_substring(self):
+        """``no-cache="Set-Cookie"`` is still no-cache; a value must not hide it."""
+        cache = ResponseCache(ttl=60)
+        cache.clear_cache()
+
+        first = make_request(url="/api/qualified")
+        resp = make_response(body='{"token": "ALICE-SECRET"}')
+        resp.header("Cache-Control", 'no-cache="Set-Cookie"')
+        cache.before_cache(first, resp)
+        cache.after_cache(first, resp)
+
+        out = serve(cache, make_request(url="/api/qualified"), make_response())
+        assert "ALICE-SECRET" not in body_of(out)
+
+
+class TestSessionCookieIsolation:
+    """RFC 9111 s3, applied to the caller identified by a session rather than by
+    an Authorization header.
+
+    The key is method + URL, so storing a response built for a signed-in caller
+    replays it to whoever requests that URL next. Tina4's own session mechanism
+    is a cookie, so guarding Authorization alone left every session-authenticated
+    page replayable — reachable on a stock install through the documented
+    ``middleware=["ResponseCache:300"]`` form.
+    """
+
+    def test_one_sessions_response_is_not_replayed_to_another(self):
+        cache = ResponseCache(ttl=60)
+        cache.clear_cache()
+
+        alice = make_request(url="/api/me", headers={"Cookie": "session=ALICE"})
+        alice_resp = make_response(body='{"user": "ALICE", "cart_total": "R 1499.00"}')
+        cache.before_cache(alice, alice_resp)
+        cache.after_cache(alice, alice_resp)
+
+        bob = make_request(url="/api/me", headers={"Cookie": "session=BOB"})
+        assert "ALICE" not in body_of(serve(cache, bob, make_response()))
+
+        anon = make_request(url="/api/me")
+        assert "ALICE" not in body_of(serve(cache, anon, make_response()))
+
+    def test_a_response_installing_a_session_is_not_stored(self):
+        """Set-Cookie on the way out marks the body as built for one caller."""
+        cache = ResponseCache(ttl=60)
+        cache.clear_cache()
+
+        first = make_request(url="/api/login-landing")
+        resp = make_response(body='{"welcome": "ALICE"}')
+        resp.header("Set-Cookie", "session=ALICE; Path=/; HttpOnly")
+        cache.before_cache(first, resp)
+        cache.after_cache(first, resp)
+
+        out = serve(cache, make_request(url="/api/login-landing"), make_response())
+        assert "ALICE" not in body_of(out)
+
+    def test_a_cookie_bearing_request_still_caches_when_marked_public(self):
+        """The same s3.5 escape hatch the Authorization path already honours."""
+        cache = ResponseCache(ttl=60)
+        cache.clear_cache()
+
+        req = make_request(url="/api/products", headers={"Cookie": "session=ALICE"})
+        resp = make_response(body='{"products": []}')
+        resp.header("Cache-Control", "public, max-age=60")
+        cache.before_cache(req, resp)
+        cache.after_cache(req, resp)
+
+        later = make_request(url="/api/products", headers={"Cookie": "session=BOB"})
+        assert body_of(serve(cache, later, make_response())) == '{"products": []}'
+
+    def test_traffic_without_cookies_is_unaffected(self):
+        """Positive control: the ordinary public GET path keeps its hit rate."""
+        cache = ResponseCache(ttl=60)
+        cache.clear_cache()
+
+        req = make_request(url="/api/anon")
+        resp = make_response(body='{"public": true}')
+        cache.before_cache(req, resp)
+        cache.after_cache(req, resp)
+
+        out = serve(cache, make_request(url="/api/anon"), make_response())
+        assert body_of(out) == '{"public": true}'
+        assert header_of(out, "X-Cache") == "HIT"
+
+
 class TestVary:
     """RFC 9111 s4.1: a stored response with Vary is only reusable when every
     nominated request header matches the request that caused it to be stored."""

--- a/tina4_python/cache/__init__.py
+++ b/tina4_python/cache/__init__.py
@@ -1190,6 +1190,17 @@ def _vary_fields(response) -> list:
     return [f.strip().lower() for f in raw.split(",") if f.strip()]
 
 
+def _cache_control_tokens(carrier) -> set:
+    """The Cache-Control directive names on a request or response, lowercased.
+
+    Parsed as comma-separated tokens with any ``=value`` stripped, rather than by
+    substring search, so ``no-cache="Set-Cookie"`` is recognised as ``no-cache``
+    and a directive name never matches as a fragment of a longer one.
+    """
+    raw = _header_value(carrier, "Cache-Control") or ""
+    return {token.split("=", 1)[0].strip().lower() for token in raw.split(",") if token.strip()}
+
+
 def _shared_cache_allowed(response) -> bool:
     """Does the response carry a directive that lets a shared cache store it?"""
     cc = (_header_value(response, "Cache-Control") or "").lower()
@@ -1373,10 +1384,34 @@ class ResponseCache:
           URL, because the key is method + URL only.
         * s4.1 — "A stored response with a Vary header field value containing a
           member '*' always fails to match", so storing one is pointless.
+
+        The same s3 reasoning applies to two cases the Authorization check alone
+        does not cover, and both were storable before 3.13.108:
+
+        * ``no-store`` forbids storage in any cache and ``private`` forbids it in
+          a shared one. Neither was honoured, so a handler had no way at all to
+          keep a response out of this cache — setting the correct standard header
+          did nothing.
+        * A caller identified by a session cookie is as specific as one carrying
+          Authorization, and Tina4's own session mechanism IS a cookie. Because
+          the key is method + URL, storing such a response replays one signed-in
+          user's page to whoever asks for that URL next. A response that installs
+          a session is per-user by construction for the same reason.
+
+        Both cookie cases stay cacheable when the response opts in explicitly with
+        a shared-cache directive, which is how a genuinely public page served to
+        cookie-bearing browsers keeps its hit rate.
         """
         if "*" in _vary_fields(response):
             return False
+        directives = _cache_control_tokens(response)
+        if directives & {"no-store", "private", "no-cache"}:
+            return False
         if _header_value(request, "Authorization") is not None:
+            return _shared_cache_allowed(response)
+        if _header_value(request, "Cookie") is not None:
+            return _shared_cache_allowed(response)
+        if _header_value(response, "Set-Cookie") is not None:
             return _shared_cache_allowed(response)
         return True
 


### PR DESCRIPTION
## Summary

`ResponseCache` serves one signed-in user's response to the next caller of the same URL. On a stock install this is reachable through the form the documentation teaches — `docs/python/11-caching.md:178`:

```python
@get("/api/products", middleware=["ResponseCache:300"])
```

No `@cached` involved, no unusual configuration. Any route rendering session-derived data behind that middleware discloses it to other users.

## Measured on 3.13.107, over real HTTP

Two requests to the same URL, each sending its own session cookie:

```
ALICE  Cookie: session=alice_session_token
  -> X-Cache: MISS  {"user":"Alice Smith","account_number":"ACC-9921","balance":"$84,250.00"}

BOB    Cookie: session=bob_session_token
  -> X-Cache: HIT   {"user":"Alice Smith","account_number":"ACC-9921","balance":"$84,250.00"}
```

`X-Cache: HIT` — Bob's handler never ran. He received Alice's account number and balance.

There is also no way for a handler to opt out. The strings `no-store`, `private` and `no-cache` appear nowhere in `tina4_python/cache/__init__.py`, so a response carrying the correct standard directive is stored and replayed anyway.

## Cause

`cache_key()` is method plus URL only, and `_may_store` guarded exactly two things: a `Vary` value of `*`, and the `Authorization` request header. A request carrying a `Cookie` and no `Authorization` fell through to a bare `return True`.

Tina4's own session mechanism is a cookie, so every session-authenticated page was storable and replayable.

`_vary_matches` already implements RFC 9111 §4.1 correctly, but it never helps here: the key ignores `Vary`, so entries collide on one slot rather than varying per user.

## Change

`_may_store` now:

- refuses storage when the response carries `no-store`, `private` or `no-cache` — RFC 9111 §3: `no-store` forbids storage in any cache, `private` forbids it in a shared one;
- treats a `Cookie` request header and a `Set-Cookie` response header the way `Authorization` is already treated — storable only when the response opts in with an explicit shared-cache directive.

`Cache-Control` is now parsed as comma-separated tokens with any `="value"` stripped rather than by substring search, so `no-cache="Set-Cookie"` is recognised as `no-cache` and a directive name cannot match as a fragment of a longer one.

**Public traffic is unaffected.** A cookie-bearing request whose response is marked `public` or `s-maxage` still caches, and cookieless traffic still returns `X-Cache: HIT`.

## Tests

Eight tests across `TestNoStoreAndPrivate` and `TestSessionCookieIsolation`, following the existing `TestVary` / Authorization house style with the real `Request` and `Response`. Six fail against unfixed source; the other two are controls proving the cache is not merely disabled.

Full suite on this branch: 5074 passed, 622 skipped, 5 failed — the same 5 pre-existing environment failures present on an unmodified `v3` worktree (firebird connect timeout, three port-takeover contract tests, and the CLAUDE.md version check).
