### PR TITLE
fix(service): ServiceRunner.stop() never stops a class-based service

### DIFF
--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,7 +4,7 @@ import threading
 import pytest
 from datetime import datetime
 from tina4_python.service import (
-    ServiceRunner, ServiceContext, parse_cron, cron_matches, _field_matches,
+    Service, ServiceRunner, ServiceContext, parse_cron, cron_matches, _field_matches,
 )
 
 
@@ -263,3 +263,118 @@ class TestServiceRunnerDiscover:
         runner = ServiceRunner()
         discovered = runner.discover(str(tmp_path))
         assert discovered == []
+
+
+class TestServiceRunnerClassBasedServiceStop:
+
+    @pytest.mark.slow
+    def test_stop_stops_class_based_service_and_reclaims_thread(self):
+        class LoopingService(Service):
+            def __init__(self):
+                super().__init__()
+                self.count = 0
+
+            def run(self):
+                while not self.should_stop():
+                    self.count += 1
+                    time.sleep(0.01)
+
+        svc = LoopingService()
+        runner = ServiceRunner()
+        runner.register_service("looping-svc", svc)
+        runner.start()
+
+        time.sleep(0.05)
+        assert svc.count > 0
+
+        start_time = time.time()
+        runner.stop()
+        elapsed = time.time() - start_time
+
+        # (a) stop() returns well under 5 s join timeout
+        assert elapsed < 2.0
+
+        # (b) counter stops climbing after stop() returns
+        count_at_stop = svc.count
+        time.sleep(0.05)
+        assert svc.count == count_at_stop
+
+        # (c) no svc-<name> thread is left in threading.enumerate()
+        thread_names = [t.name for t in threading.enumerate()]
+        assert "svc-looping-svc" not in thread_names
+
+    def test_stop_handles_raising_service_instance_stop(self):
+        class ServiceA(Service):
+            def __init__(self):
+                super().__init__()
+                self.count = 0
+
+            def run(self):
+                while not self.should_stop():
+                    self.count += 1
+                    time.sleep(0.01)
+
+            def stop(self):
+                super().stop()
+                raise RuntimeError("Boom in service A stop")
+
+        class ServiceB(Service):
+            def __init__(self):
+                super().__init__()
+                self.count = 0
+
+            def run(self):
+                while not self.should_stop():
+                    self.count += 1
+                    time.sleep(0.01)
+
+        svca = ServiceA()
+        svcb = ServiceB()
+        runner = ServiceRunner()
+        runner.register_service("service-a", svca)
+        runner.register_service("service-b", svcb)
+        runner.start()
+
+        time.sleep(0.05)
+        assert svca.count > 0
+        assert svcb.count > 0
+
+        # stop() should not raise even if svca.stop() raises
+        runner.stop()
+
+        # service B's counter stopped climbing after stop() returned
+        count_b_at_stop = svcb.count
+        time.sleep(0.05)
+        assert svcb.count == count_b_at_stop
+
+        # neither svc- thread survives in threading.enumerate()
+        thread_names = [t.name for t in threading.enumerate()]
+        assert "svc-service-a" not in thread_names
+        assert "svc-service-b" not in thread_names
+
+    def test_plain_callable_stops_via_stop_event(self):
+        count = [0]
+
+        def worker(ctx):
+            while not ctx.stop_event.is_set():
+                count[0] += 1
+                time.sleep(0.01)
+
+        runner = ServiceRunner()
+        runner.register("callable-worker", worker, daemon=True)
+        runner.start()
+
+        time.sleep(0.05)
+        assert count[0] > 0
+
+        start_time = time.time()
+        runner.stop()
+        elapsed = time.time() - start_time
+
+        assert elapsed < 2.0
+        count_at_stop = count[0]
+        time.sleep(0.05)
+        assert count[0] == count_at_stop
+        thread_names = [t.name for t in threading.enumerate()]
+        assert "svc-callable-worker" not in thread_names
+

--- a/tina4_python/service/__init__.py
+++ b/tina4_python/service/__init__.py
@@ -356,6 +356,16 @@ class ServiceRunner:
 
         for svc in self.services:
             svc["running"] = False
+            instance = svc.get("instance")
+            if instance is not None and hasattr(instance, "stop") and callable(instance.stop):
+                try:
+                    instance.stop()
+                except Exception as exc:
+                    _get_log().error(
+                        "Error stopping service instance",
+                        name=svc.get("name"),
+                        error=str(exc),
+                    )
 
         # Give threads a moment to finish
         for t in self._threads:


### PR DESCRIPTION
## Summary

`docs/python/27-service-runner.md:224` states:

> `stop()` calls `stop()` on each registered service and waits for their threads to finish.

It does not. `ServiceRunner.stop()` never calls the instance's `stop()`, so a class-based service written the way the `Service` docstring documents never exits its loop — `stop()` blocks the full 5 s join, gives up, and returns while the thread is still running.

This is a published contract that stopped being true, not a new feature.

## Measured on 3.13.107

A `Service` subclass whose `run()` loops on `while not self.should_stop():`, registered with `register_service()`:

```
stop() duration:            5.0036 s      (the full join timeout)
counter at stop() return:   510
counter 200 ms later:       529           (delta 19 — still running)
svc-class_service thread:   still in threading.enumerate()
```

After the change:

```
stop() duration:            0.0050 s
counter delta after return: 0
thread:                     gone
```

## Cause

`register_service()` stores the instance at `tina4_python/service/__init__.py:324`:

```python
"instance": service,  # keep reference so stop() can route to service.stop()
```

That key is written and read nowhere else in the file — the routing the comment describes was never implemented.

`stop()` sets `self._stop_event`, sets `svc["running"] = False`, and joins with `timeout=5`. `Service.should_stop()` returns `not self._running`, and `self._running` is cleared only by `Service.stop()`. Nothing ever calls it, so the documented loop cannot terminate.

## Change

`ServiceRunner.stop()` now calls `instance.stop()` for every service carrying one, before joining the threads, inside a guarded `try`/`except` so one service's failing `stop()` cannot prevent the rest from stopping or block the join. Follows the existing `_get_log().error(...)` idiom in this file.

**The plain-callable path is untouched.** Services registered via `register()` observe `ctx.stop_event`, which `stop()` already sets; that remains the behaviour and is covered by a control test.

## Tests

Three tests in `tests/test_service.py`:

- the documented loop stops promptly, the counter stops advancing, and no `svc-<name>` thread survives — fails on unfixed source with `assert 5.000515460968018 < 2.0`;
- two services where the first one's `stop()` raises after `super().stop()`, asserting the second still stops — fails on unfixed source with `assert 994 == 989`;
- a control confirming the plain-callable `register()` path still stops via `ctx.stop_event`, which passes both before and after.

Full suite on this branch: 5069 passed, 622 skipped, 5 failed — the same 5 pre-existing environment failures present on an unmodified `v3` worktree (firebird connect timeout, three port-takeover contract tests, and the CLAUDE.md version check).
