### PR TITLE
fix(database): connect-timeout message loses a race to the driver's own

### DIFF
--- a/tests/test_database_connect_timeout.py
+++ b/tests/test_database_connect_timeout.py
@@ -33,6 +33,7 @@ from tina4_python.database.adapter import (
     CONNECT_TIMEOUT_VARIABLE,
     DEFAULT_CONNECT_TIMEOUT_SECONDS,
     DatabaseConnectTimeout,
+    bound_was_reached,
     call_with_deadline,
     driver_connect_timeout_seconds,
     resolve_connect_timeout,
@@ -266,17 +267,84 @@ def test_framework_message_wins_over_the_drivers_own_timeout_message(
     assert not isinstance(excinfo.value.__cause__, DatabaseConnectTimeout)
 
 
-def test_driver_option_is_never_shorter_than_the_configured_bound():
-    """The invariant that makes the wrapper work.
+def test_driver_option_is_strictly_longer_than_the_configured_bound():
+    """The invariant that makes the wrapper work — and it has to be STRICT.
 
-    If the driver's option were ever SHORTER than our bound, the driver would
-    raise before ``elapsed`` reached the bound, the wrapper would decline to
-    translate it, and a bare driver message would reach the caller. Rounding UP
-    is what prevents that, so it is pinned here across the awkward values.
+    This wrapper runs no competing countdown. It waits for the driver to abort
+    at the DRIVER's deadline and then restates that failure in the framework's
+    words. For that to happen the driver's deadline has to land AFTER ours,
+    which means its option must be strictly greater than our bound — not merely
+    not-shorter.
+
+    ``ceil`` gave equality for every whole-second bound, and the shipped
+    default is whole. Equality is not separation: both deadlines sat on the
+    same instant, and which message reached the caller came down to which clock
+    moved first. An assertion of ``>=`` passes with that bug still in place,
+    which is exactly why this one asserts ``>``.
     """
     for configured in (0.2, 0.5, 1.0, 1.4, 2.0, 2.5, 9.99, 10.0, 30.0):
         option = driver_connect_timeout_seconds(configured)
-        assert option >= configured, (configured, option)
+        assert option > configured, (
+            f"a bound of {configured}s got a driver option of {option}s — the "
+            f"driver can abort at or before our own deadline"
+        )
+
+
+# ── The bound counts as reached on EITHER clock, because the driver uses the other ──
+
+
+def test_bound_reached_on_the_monotonic_reading_is_a_timeout():
+    """The ordinary case: the clocks agree and monotonic alone settles it."""
+    assert bound_was_reached(2.0, 2.0, 2.0)
+    assert bound_was_reached(2.5, 2.5, 2.0)
+
+
+def test_bound_reached_on_the_realtime_reading_alone_is_still_a_timeout():
+    """The case that was leaking the driver's own message to operators.
+
+    libpq measures its ``connect_timeout`` with ``gettimeofday`` —
+    CLOCK_REALTIME — while a duration in Python belongs on
+    ``time.monotonic()``. NTP slews and steps realtime and never touches
+    monotonic, so realtime can reach the bound while a monotonic reading over
+    the very same connect is still short of it. By then the driver has already
+    aborted; returning False here hands the caller libpq's "timeout expired",
+    which names nothing they can tune.
+
+    The numbers are the ones measured against a real wedged PostgreSQL socket
+    with the two clocks made to diverge: the driver gave up 1.56s into a 2s
+    bound, by which time realtime had run on to 2.03s.
+    """
+    assert bound_was_reached(1.56, 2.03, 2.0)
+
+
+def test_a_backward_realtime_step_cannot_hide_a_real_timeout():
+    """Why the monotonic reading stays in the comparison.
+
+    A backward step leaves the realtime reading small, or negative. Trusting
+    realtime alone would then swallow an expiry that really did take the whole
+    bound — so the comparison keeps both and takes the larger.
+    """
+    assert bound_was_reached(2.01, -30.0, 2.0)
+
+
+def test_a_failure_faster_than_the_bound_is_a_timeout_on_neither_clock():
+    """A refusal, bad credentials, an unknown database.
+
+    These arrive in milliseconds on both clocks and have to be re-raised
+    untouched: dressing one up as an expiry sends an operator hunting a network
+    stall that never happened.
+    """
+    assert not bound_was_reached(0.001, 0.001, 2.0)
+    assert not bound_was_reached(1.999, 1.999, 2.0)
+
+
+def test_an_unbounded_connect_is_never_reported_as_a_timeout():
+    """``TINA4_DATABASE_CONNECT_TIMEOUT=0`` means wait forever.
+
+    With no bound there is nothing a failure can have exceeded, however long it
+    took, so the driver's own error must survive untranslated.
+    """
+    assert not bound_was_reached(9999.0, 9999.0, None)
 
 
 # ── NEGATIVE: a fast failure must NOT be dressed up as a timeout ──

--- a/tina4_python/database/adapter.py
+++ b/tina4_python/database/adapter.py
@@ -62,16 +62,41 @@ def resolve_connect_timeout() -> float | None:
 
 
 def driver_connect_timeout_seconds(seconds: float | None) -> int | None:
-    """A driver's own connect-timeout option value, rounded UP to whole seconds.
+    """A driver's own connect-timeout option, in whole seconds, STRICTLY longer
+    than the bound it protects.
 
     Every driver option here (libpq ``connect_timeout``, mysql-connector
     ``connection_timeout``, pymssql ``login_timeout``, pyodbc ``timeout``) is
-    whole seconds. Rounding UP matters: a driver that fired EARLY — at 2s for a
-    configured 2.5s — would raise its own raw error before our bound was
-    reached, and the caller would see a bare driver message instead of one
-    naming the variable that caused it.
+    whole seconds, so the bound has to become an integer — and which integer
+    decides whether the driver's deadline lands after ours or on top of it.
+    ``ceil`` put it on top: for a whole-second bound ``ceil(N) == N``, and the
+    shipped default of 10 is whole. ``floor(s) + 1`` is strictly greater for
+    every input, fractional or whole, which is what leaves the driver's own
+    timer the room to fire first — the thing this wrapper is built on. The
+    cost is at most one extra second, on a path that has already failed.
     """
-    return None if seconds is None else max(1, math.ceil(seconds))
+    return None if seconds is None else max(1, math.floor(seconds) + 1)
+
+
+def bound_was_reached(elapsed_monotonic: float, elapsed_realtime: float,
+                      seconds: float | None) -> bool:
+    """Did a connect that failed take at least the configured bound?
+
+    Two readings, because the framework and the driver do not share a clock.
+    :func:`connect_deadline` times on ``time.monotonic()``; libpq times its own
+    ``connect_timeout`` on ``gettimeofday()``. NTP moves the wall clock and
+    never touches the monotonic one, so a forward step or slew can make the
+    driver abort before a monotonic reading has reached the bound.
+
+    Taking the LARGER of the two readings covers both directions: the realtime
+    reading catches a forward jump, and keeping the monotonic reading means a
+    BACKWARD jump cannot hide a timeout that really did happen.
+
+    Pure, so the decision is testable without faking a clock.
+    """
+    if seconds is None:
+        return False
+    return max(elapsed_monotonic, elapsed_realtime) >= seconds
 
 
 @contextlib.contextmanager
@@ -105,19 +130,39 @@ def connect_deadline(host, port):
     throws away the driver's own diagnosis, and for the watchdog adapters it
     would abandon a thread the driver could have unwound itself.
 
-    The invariant that makes this work: the driver's option is always >= our
-    bound (:func:`driver_connect_timeout_seconds` rounds UP), and our clock
-    starts BEFORE the call, so the driver's own timeout cannot expire before
-    ``elapsed`` has reached our bound. Break either half and a bare driver
-    message reaches the caller instead of ours.
+    THE INVARIANT, AND WHY IT TAKES TWO CLOCKS
+    ------------------------------------------
+    What decides the race is not the driver's OPTION against our bound — it
+    is the driver's ABORT INSTANT against our reading of a clock. Two things
+    have to hold, and each of them was broken:
+
+    * The driver's option must be STRICTLY greater than our bound, so its
+      deadline lands after ours instead of on top of it.
+      :func:`driver_connect_timeout_seconds` returns ``floor(s) + 1`` for that
+      reason; ``ceil`` left a whole-second bound with no separation at all, and
+      the default bound is a whole number.
+
+    * The comparison has to be made on the clock the DRIVER used. libpq times
+      ``connect_timeout`` with ``gettimeofday()`` — CLOCK_REALTIME — while a
+      duration in Python belongs on ``time.monotonic()``. NTP slews and steps
+      realtime and never touches monotonic, so a monotonic reading can still
+      sit below the bound at the instant the driver has already given up, and
+      then the driver's own message — which names no tunable — reaches
+      the caller. :func:`bound_was_reached` compares both readings.
+
+    Break either half and a bare driver message reaches the caller instead of
+    ours.
     """
     seconds = resolve_connect_timeout()
     started = time.monotonic()
+    started_realtime = time.time()
     try:
         yield seconds
     except Exception as failure:
-        elapsed = time.monotonic() - started
-        if seconds is not None and elapsed >= seconds:
+        elapsed_monotonic = time.monotonic() - started
+        elapsed_realtime = time.time() - started_realtime
+        elapsed = max(elapsed_monotonic, elapsed_realtime)
+        if bound_was_reached(elapsed_monotonic, elapsed_realtime, seconds):
             raise DatabaseConnectTimeout(
                 f"Database connect to {host}:{port} timed out after {elapsed:.1f}s "
                 f"({CONNECT_TIMEOUT_VARIABLE}={seconds:g} seconds). "


### PR DESCRIPTION
## Summary

`TINA4_DATABASE_CONNECT_TIMEOUT` exists so an operator who hits a wedged database gets an error naming the variable they can tune. For the two adapters that lean on the driver's own timer, `connect_deadline` does not run a competing countdown — it lets the driver abort and then **translates** that failure, keeping the driver's error as `__cause__`. Its docstring is explicit that the translation cannot be missed.

It can be missed, because the two sides measure the bound on different clocks.

- `connect_deadline` (`tina4_python/database/adapter.py:115`) stamps `time.monotonic()` — `CLOCK_MONOTONIC` — and translates only when `elapsed >= seconds`.
- libpq measures its own `connect_timeout` with `gettimeofday()` — `CLOCK_REALTIME`. From the driver binary rather than by inference:

```
$ nm -D --undefined-only .venv/.../psycopg2/_psycopg.cpython-313-x86_64-linux-gnu.so
                 U gettimeofday@GLIBC_2.2.5
```

No `clock_gettime` import at all, so nothing in libpq reads the clock the framework is using. NTP slews and steps realtime and never touches monotonic.

And there was no separation to absorb the difference. `driver_connect_timeout_seconds` rounded up with `ceil`, so for a whole-second bound `ceil(N) == N` and the driver's deadline sat on the same instant as ours. `DEFAULT_CONNECT_TIMEOUT_SECONDS = 10.0` is whole, so this is the default configuration, not an edge case.

## Measured on released 3.13.107

A real `PostgreSQLAdapter().connect()` against a real wedged socket, with realtime made to run ahead of monotonic by an `LD_PRELOAD` shim — no mocks, no monkeypatching. Bound 2s throughout.

| | clocks agree | realtime 1.3x | realtime 2.0x | wait on the failure path |
|---|---|---|---|---|
| before | holds, 2.0162s | **breaks, 1.5641s** | **breaks, 1.5157s** | 2.0s |
| after | holds, 3.0159s | holds, 2.5651s | holds, 1.5161s | 3.0s |

*holds* = `DatabaseConnectTimeout`, whose message names the variable. *breaks* = `psycopg2.OperationalError: connection to server at "127.0.0.1", port N failed: timeout expired`, which names nothing.

This also shows up as an intermittent CI failure in this repo's own suite — `tests/test_database_connect_timeout.py` has failed on `v3` and on unrelated pull requests with exactly that message, on commits that pass on a rerun. The window is narrow: logging every `gettimeofday` call during a connect to a silent server shows libpq reading realtime 4 times inside the first 52 microseconds and then once when `poll()` returns, so only a jump landing in that ~52 µs can shorten the wait. Rare per connect, which is why it presents as a flake.

## Changes

**`driver_connect_timeout_seconds` returns `max(1, math.floor(seconds) + 1)`** — strictly greater than the bound for every input, whole or fractional, so the driver's deadline lands after ours instead of on top of it. Costs at most one extra second, on a path that has already failed.

**`bound_was_reached(elapsed_monotonic, elapsed_realtime, seconds)`** — a new pure function taking the larger of the two readings. The realtime reading catches a forward jump; keeping the monotonic reading means a backward jump cannot hide a timeout that really did happen. Pure so the decision is testable without faking a clock, which no test in this suite does.

`connect_deadline` stamps both clocks and passes both readings. The invariant paragraph in its docstring stated the rule as the driver's *option* against our bound; what decides the race is the driver's *abort instant* against our reading of a clock, so it is rewritten to say that.

**Unaffected:** the watchdog adapters (`mssql`, `odbc`, `firebird`) time on a worker thread via `call_with_deadline`, monotonic on both sides, and were never exposed to this comparison.

## Tests

`test_driver_option_is_never_shorter_than_the_configured_bound` asserted `option >= configured`, which passes with the defect in place. It is renamed to `test_driver_option_is_strictly_longer_than_the_configured_bound` and asserts `>`; against unfixed source it fails with `assert 1 > 1.0`.

Five cases on `bound_was_reached`: the ordinary monotonic case, the realtime-only case using the measured numbers (`1.56`, `2.03`, `2.0`), a backward-step case pinning why monotonic stays in the comparison, a fast-failure case, and the unbounded case.

Both pre-existing pinned assertions are untouched and still pass — `driver_connect_timeout_seconds(2.5) == 3` and `(0.2) == 1`.

Verified failing against unfixed source two ways: with the change removed the test module cannot import `bound_was_reached`, and with the helper present but `ceil` restored the strict-option test fails as above.

`tests/test_database_connect_timeout.py`: 22 passed, 4 skipped, 1 failure — `test_firebird_connect_is_bounded_against_a_black_hole_server`, which fails identically without this change because `libfbclient.so` is not installed locally. Full suite on this branch: 5065 passed, 632 skipped, that same 1 failure.
