### PR TITLE
skills: full-stack project layout + ask-backend-framework paradigm

### DIFF
--- a/.claude/skills/tina4-developer-python/SKILL.md
+++ b/.claude/skills/tina4-developer-python/SKILL.md
@@ -222,6 +222,39 @@ A feature plan has four parts — a Scope checklist, the Tests, a Bugs section, 
 ## Status: In Progress
 ```
 
+### Project layout — components live in their own folders
+
+Never pollute the project ROOT with source code. The root is for orchestration and
+docs only: `plan/` (the overview dashboard), `README.md`, `TINA4.md`, and shared
+config. Source lives in COMPONENT folders.
+
+- A single standalone frontend (one `index.html` + assets) may sit at the root.
+- The moment a build has BOTH a frontend AND a backend, split them and keep the
+  root clean:
+
+```
+plan/            # ROOT overview dashboard — links each component's plan/
+README.md
+TINA4.md
+backend/         # ALL backend source
+  plan/          # backend's own plans, linked from root plan/MASTER.md
+frontend/        # ALL frontend source
+  plan/          # frontend's own plans, linked from root plan/MASTER.md
+```
+
+- The root `plan/` is the single overview; each component keeps ITS plans in its own
+  `plan/` folder, referenced from the root `plan/MASTER.md`. Mirror the code's folder
+  structure with plan/ folders (see the plan-folder rules above).
+- Do NOT write server files or app files loose in the root of a full-stack build. If
+  you are about to write `server.*`/`index.html` at the root of a full-stack build,
+  stop and put it under `backend/` or `frontend/`.
+
+**Ask the backend framework — never assume.** When a build needs a backend (an API,
+a database, auth, server-side logic — anything beyond a static frontend) and the
+stack is not already decided, ASK which framework BEFORE scaffolding it. Offer the
+Tina4 stacks first — Tina4 (Python / Node.js / PHP / Ruby) — then "other". Record the
+choice in `TINA4.md` so it holds for the whole project.
+
 ### 4. Tests first — real tests, never smoke tests
 Write the tests **before** the code, and make them real: they hit the actual dependency (a real
 SQLite file, a real HTTP request, a real temp dir), assert real behaviour, and **fail before the

--- a/.claude/skills/tina4-js/SKILL.md
+++ b/.claude/skills/tina4-js/SKILL.md
@@ -191,6 +191,39 @@ A feature plan has four parts — a Scope checklist, the Tests, a Bugs section, 
 ## Status: In Progress
 ```
 
+### Project layout — components live in their own folders
+
+Never pollute the project ROOT with source code. The root is for orchestration and
+docs only: `plan/` (the overview dashboard), `README.md`, `TINA4.md`, and shared
+config. Source lives in COMPONENT folders.
+
+- A single standalone frontend (one `index.html` + assets) may sit at the root.
+- The moment a build has BOTH a frontend AND a backend, split them and keep the
+  root clean:
+
+```
+plan/            # ROOT overview dashboard — links each component's plan/
+README.md
+TINA4.md
+backend/         # ALL backend source
+  plan/          # backend's own plans, linked from root plan/MASTER.md
+frontend/        # ALL frontend source
+  plan/          # frontend's own plans, linked from root plan/MASTER.md
+```
+
+- The root `plan/` is the single overview; each component keeps ITS plans in its own
+  `plan/` folder, referenced from the root `plan/MASTER.md`. Mirror the code's folder
+  structure with plan/ folders (see the plan-folder rules above).
+- Do NOT write server files or app files loose in the root of a full-stack build. If
+  you are about to write `server.*`/`index.html` at the root of a full-stack build,
+  stop and put it under `backend/` or `frontend/`.
+
+**Ask the backend framework — never assume.** When a build needs a backend (an API,
+a database, auth, server-side logic — anything beyond a static frontend) and the
+stack is not already decided, ASK which framework BEFORE scaffolding it. Offer the
+Tina4 stacks first — Tina4 (Python / Node.js / PHP / Ruby) — then "other". Record the
+choice in `TINA4.md` so it holds for the whole project.
+
 ### 4. Tests first — real behaviour, never smoke tests
 Pin the behaviour before you build the component: assert against the **real rendered DOM** (a real
 signal, a real `` html`` `` render), or run the dev server and drive the real UI — and make it fail


### PR DESCRIPTION
## What

Adds a **Project layout** section to the `tina4-developer-python` and `tina4-js` skills so agents follow a consistent full-stack paradigm:

- **Never pollute the project root with source code.** Root holds `plan/`, `README.md`, `TINA4.md`, and shared config only.
- A build with **both a frontend and a backend** splits into `backend/` and `frontend/` folders, each with its **own `plan/` folder**, all referenced from the **single root `plan/` overview** (mirrors the existing plan-folder rules).
- **Ask the backend framework before scaffolding** — offer the Tina4 stacks (Python / Node.js / PHP / Ruby) first, record the choice in `TINA4.md`.

## Why

Agents were dumping backend + frontend source into the project root and never asking which backend framework to use. This codifies the layout + clarify paradigm so every Tina4 skill (all four dev languages + tina4-js) teaches it identically.

Sibling PRs apply the same section to `tina4-php`, `tina4-ruby`, and `tina4-nodejs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)