### PR TITLE
fix(swagger): point the bundled UI at a document that exists

### DIFF
--- a/tests/test_swagger_static_gate.py
+++ b/tests/test_swagger_static_gate.py
@@ -22,10 +22,12 @@ No doubles.
 """
 
 import os
+import re
 from pathlib import Path
 
 import tina4_python
 from tina4_python.core.server import _try_static
+from tina4_python.test_client import TestClient
 
 FRAMEWORK_PUBLIC = Path(tina4_python.__file__).resolve().parent / "public"
 
@@ -155,3 +157,56 @@ def test_non_swagger_static_unaffected_by_the_gate():
         )
     finally:
         _restore_env(previous)
+
+
+# ── The asset must also be USABLE, not merely gated ─────────────────────────
+#
+# The gate above answers "may this be served". It cannot answer "is what we
+# serve any use", and that turned out to matter: the bundled index.html asked
+# SwaggerUIBundle for
+#
+#     url: "{SWAGGER_ROUTE}/swagger.json"
+#
+# and SWAGGER_ROUTE was the only occurrence of that token in the package, so
+# nothing ever substituted it -- while swagger.json is not a path this framework
+# routes either. Every gated path therefore answered 200 with a Swagger UI that
+# could never load its document. /swagger and /swagger/ hid it, because
+# server.py handles those two inline and never reaches the static file; the
+# unguarded ways in were /swagger//, which index-resolves, and
+# /swagger/index.html by name.
+#
+# So the property is not about status codes. For every path that hands a browser
+# a Swagger UI page, the document URL THAT PAGE NAMES must be one this server
+# answers. Asserting a 200 on a hardcoded /swagger/openapi.json would have
+# passed throughout.
+
+# Every way to end up on a Swagger UI page. The first two are served inline by
+# the server, the last two by the bundled static asset -- which is the point:
+# the property must hold no matter which of the two answers.
+UI_PATHS = ("/swagger", "/swagger/", "/swagger//", "/swagger/index.html")
+
+_UI_DOCUMENT_URL = re.compile(r'url:\s*"([^"]+)"')
+
+
+def test_every_swagger_ui_page_names_a_document_that_resolves(monkeypatch):
+    """However you reach the UI, the document it asks for must answer 200."""
+    monkeypatch.setenv("TINA4_SWAGGER_ENABLED", "true")
+    client = TestClient()
+
+    for path in UI_PATHS:
+        page = client.get(path)
+        assert page.status == 200, f"{path} returned {page.status}, expected 200"
+
+        html = page.body.decode(errors="replace")
+        match = _UI_DOCUMENT_URL.search(html)
+        assert match, f"{path} served a page with no document url: to check"
+        document_url = match.group(1)
+
+        # Read out of the HTML that was actually served, then fetched. A page
+        # naming an unsubstituted {SWAGGER_ROUTE} placeholder fails right here.
+        served = client.get(document_url)
+        assert served.status == 200, (
+            f"the page at {path} asks for {document_url!r}, which answered "
+            f"{served.status} -- that UI can never load"
+        )
+        assert "application/json" in served.content_type, served.content_type

--- a/tina4_python/public/swagger/index.html
+++ b/tina4_python/public/swagger/index.html
@@ -71,7 +71,7 @@
 
         // Build a system
         const ui = SwaggerUIBundle({
-            url: "{SWAGGER_ROUTE}/swagger.json",
+            url: "/swagger/openapi.json",
             dom_id: '#swagger-ui',
             deepLinking: true,
             presets: [


### PR DESCRIPTION
## The defect

The bundled Swagger UI page asks the browser for `{SWAGGER_ROUTE}/swagger.json`. That placeholder
is **never substituted** — nothing in the static path templates the file, it is served
byte-for-byte off disk — so the browser requests the literal string, which 404s. The page loads,
renders the Swagger chrome, and then shows an error where the API should be.

`swagger.json` is not a route in this port, or in any of the others. The document is served at
`/swagger/openapi.json`.

## Where it is reachable

`core/server.py:1704` already claims both canonical forms inline (`"/swagger"`, `"/swagger/"`), so
those two serve the real UI. The bundled asset is what answers:

- `GET /swagger//`
- `GET /swagger/index.html`

Both 200, both with a UI that can never load. With swagger disabled all forms 404
(`core/server.py:3220`), so there is no production exposure — only a UI that cannot work where one
is advertised.

## The fix

One string in `tina4_python/public/swagger/index.html`:

```diff
-            url: "{SWAGGER_ROUTE}/swagger.json",
+            url: "/swagger/openapi.json",
```

A literal is the right shape here precisely because this file is not templated. An absolute path is
also the only correct form: a relative URL resolves differently from `/swagger` than from
`/swagger/`.

## The regression test

It went into `tests/test_swagger_static_gate.py`, the file that already owns this surface. That
file was written for an earlier leak on these same assets and stops at status codes — which is
exactly why it never noticed this.

The new test asserts the **property**, not the paths: for every path form that answers with a UI
page, read the `url:` out of the HTML that was actually served and fetch it. Any page naming a
document that does not resolve fails, including forms nobody has thought of yet.

```
7 passed
```

With the one string reverted and the test kept:

```
1 failed, 6 passed
AssertionError: the page at /swagger// asks for '{SWAGGER_ROUTE}/swagger.json',
which answered 404 -- that UI can never load
```

## Verification

Full suite against pristine `v3` `a380345` in the same tree: base **5247 passed / 5 failed / 664
skipped**, with this branch **5248 / 5 / 664**. The five failures are **identical by name** either
way — the skill installer, a firebird connect timeout, and three port-takeover contract tests, all
needing services the test machine does not run. The `+1` is this branch's own test.

Run under `uv sync --extra test`, as CI does (`.github/workflows/test.yml:266`) — without the
extra, `tests/test_swagger_contract.py` cannot import `openapi-spec-validator`, which is declared
TEST-ONLY in the `test` extra at `pyproject.toml:99`.

## Not python-only

The same unsubstituted file ships in `tina4-nodejs` and `tina4-ruby`; both have their own pull
requests. `tina4-php` ships an equivalent page asking for `{{baseURL}}/swagger/json.json`, a token
that likewise occurs exactly once in that tree; that one has not been reproduced and has no fix yet.
